### PR TITLE
Fix NPE when variables are declared but not bound.

### DIFF
--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -68,7 +68,7 @@ public class GraphQL {
         }
 
         Validator validator = new Validator();
-        List<ValidationError> validationErrors = validator.validateDocument(graphQLSchema, document);
+        List<ValidationError> validationErrors = validator.validateDocument(graphQLSchema, document, arguments);
         if (validationErrors.size() > 0) {
             return new ExecutionResultImpl(validationErrors);
         }

--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -26,6 +26,7 @@ public enum ValidationErrorType {
     UnusedVariable,
     FragmentCycle,
     FieldsConflict,
-    InvalidFragmentType
+    InvalidFragmentType, 
+    UnboundVariable
 
 }

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -7,22 +7,23 @@ import graphql.validation.rules.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class Validator {
 
-    public List<ValidationError> validateDocument(GraphQLSchema schema, Document document) {
+    public List<ValidationError> validateDocument(GraphQLSchema schema, Document document, Map<String, Object> arguments) {
         ValidationContext validationContext = new ValidationContext(schema, document);
 
 
         ValidationErrorCollector validationErrorCollector = new ValidationErrorCollector();
-        List<AbstractRule> rules = createRules(validationContext, validationErrorCollector);
+        List<AbstractRule> rules = createRules(validationContext, validationErrorCollector, arguments);
         LanguageTraversal languageTraversal = new LanguageTraversal();
         languageTraversal.traverse(document, new RulesVisitor(validationContext, rules));
 
         return validationErrorCollector.getErrors();
     }
 
-    private List<AbstractRule> createRules(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
+    private List<AbstractRule> createRules(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector, Map<String, Object> arguments) {
         List<AbstractRule> rules = new ArrayList<>();
         ArgumentsOfCorrectType argumentsOfCorrectType = new ArgumentsOfCorrectType(validationContext, validationErrorCollector);
         rules.add(argumentsOfCorrectType);
@@ -58,6 +59,8 @@ public class Validator {
         rules.add(variablesAreInputTypes);
         VariableTypesMatchRule variableTypesMatchRule = new VariableTypesMatchRule(validationContext, validationErrorCollector);
         rules.add(variableTypesMatchRule);
+        VariablesAreBoundRule variablesAreBoundRule = new VariablesAreBoundRule(validationContext, validationErrorCollector, arguments);
+        rules.add(variablesAreBoundRule);
         return rules;
     }
 }

--- a/src/main/java/graphql/validation/rules/VariablesAreBoundRule.java
+++ b/src/main/java/graphql/validation/rules/VariablesAreBoundRule.java
@@ -1,0 +1,38 @@
+package graphql.validation.rules;
+
+import java.util.Map;
+
+import graphql.language.VariableReference;
+import graphql.validation.AbstractRule;
+import graphql.validation.ValidationContext;
+import graphql.validation.ValidationError;
+import graphql.validation.ValidationErrorCollector;
+import graphql.validation.ValidationErrorType;
+import graphql.validation.rules.VariablesTypesMatcher;
+
+public class VariablesAreBoundRule extends AbstractRule {
+
+    private final Map<String, Object> variables;
+    VariablesTypesMatcher             variablesTypesMatcher = new VariablesTypesMatcher();
+
+    public VariablesAreBoundRule(ValidationContext validationContext,
+                                 ValidationErrorCollector validationErrorCollector,
+                                 Map<String, Object> variables) {
+        super(validationContext, validationErrorCollector);
+        setVisitFragmentSpreads(true);
+        this.variables = variables;
+    }
+
+    @Override
+    public void checkVariable(VariableReference variableReference) {
+        if (variables.containsKey(variableReference.getName())) {
+            return;
+        }
+        String message = String.format("Variable not bound: '$%s'",
+                                       variableReference.getName());
+        addError(new ValidationError(ValidationErrorType.UnboundVariable,
+                                     variableReference.getSourceLocation(),
+                                     message));
+    }
+
+}


### PR DESCRIPTION
When a variable is declared in a query, but is unbound in the variables of the execution, a nasty NPE occurs.  This patch fixes the issue by providing a validation rule that verifies every declared variable is bound.  If not, produce nice errors.