### PR TITLE
mutationType is optional

### DIFF
--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -380,7 +380,7 @@ public class Introspection {
             .field(newFieldDefinition()
                     .name("mutationType")
                     .description("If this server supports mutation, the type that mutation operations will be rooted at.")
-                    .type(new GraphQLNonNull(__Type))
+                    .type(__Type)
                     .dataFetcher(new DataFetcher() {
                         @Override
                         public Object get(DataFetchingEnvironment environment) {


### PR DESCRIPTION
This fixes graphiql when no mutations are present in the schema