### PR TITLE
Change ExecutionStrategy to use ExecutionResults all the way down

### DIFF
--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public interface ExecutionResult {
 
-    Map<String, Object> getData();
+    Object getData();
 
     List<GraphQLError> getErrors();
 }

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -8,15 +8,18 @@ import java.util.Map;
 public class ExecutionResultImpl implements ExecutionResult {
 
     private final List<GraphQLError> errors = new ArrayList<>();
-    private Map<String, Object> data;
+    private Object data;
 
     public ExecutionResultImpl(List<? extends GraphQLError> errors) {
         this.errors.addAll(errors);
     }
 
-    public ExecutionResultImpl(Map<String, Object> data, List<? extends GraphQLError> errors) {
+    public ExecutionResultImpl(Object data, List<? extends GraphQLError> errors) {
         this.data = data;
-        this.errors.addAll(errors);
+
+        if (errors != null) {
+            this.errors.addAll(errors);
+        }
     }
 
     public void addErrors(List<? extends GraphQLError> errors) {
@@ -24,11 +27,11 @@ public class ExecutionResultImpl implements ExecutionResult {
     }
 
     @Override
-    public Map<String, Object> getData() {
+    public Object getData() {
         return data;
     }
 
-    public void setData(Map<String, Object> result) {
+    public void setData(Object result) {
         this.data = result;
     }
 

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -5,6 +5,7 @@ import graphql.ExecutionResultImpl;
 import graphql.GraphQLException;
 import graphql.language.Field;
 import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLType;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,12 +27,12 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
     public ExecutionResult execute(final ExecutionContext executionContext, final GraphQLObjectType parentType, final Object source, final Map<String, List<Field>> fields) {
         if (executorService == null) return new SimpleExecutionStrategy().execute(executionContext, parentType, source, fields);
 
-        Map<String, Future<Object>> futures = new LinkedHashMap<>();
+        Map<String, Future<ExecutionResult>> futures = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
             final List<Field> fieldList = fields.get(fieldName);
-            Callable<Object> resolveField = new Callable<Object>() {
+            Callable<ExecutionResult> resolveField = new Callable<ExecutionResult>() {
                 @Override
-                public Object call() throws Exception {
+                public ExecutionResult call() throws Exception {
                     return resolveField(executionContext, parentType, source, fieldList);
 
                 }
@@ -41,12 +42,13 @@ public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
         try {
             Map<String, Object> results = new LinkedHashMap<>();
             for (String fieldName : futures.keySet()) {
-                results.put(fieldName, futures.get(fieldName).get());
+                ExecutionResult executionResult = futures.get(fieldName).get();
+
+                results.put(fieldName, executionResult != null ? executionResult.getData() : null);
             }
             return new ExecutionResultImpl(results, executionContext.getErrors());
         } catch (InterruptedException | ExecutionException e) {
             throw new GraphQLException(e);
         }
-
     }
 }

--- a/src/main/java/graphql/execution/SimpleExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SimpleExecutionStrategy.java
@@ -15,8 +15,9 @@ public class SimpleExecutionStrategy extends ExecutionStrategy {
         Map<String, Object> results = new LinkedHashMap<>();
         for (String fieldName : fields.keySet()) {
             List<Field> fieldList = fields.get(fieldName);
-            Object resolvedResult = resolveField(executionContext, parentType, source, fieldList);
-            results.put(fieldName, resolvedResult);
+            ExecutionResult resolvedResult = resolveField(executionContext, parentType, source, fieldList);
+
+            results.put(fieldName, resolvedResult != null ? resolvedResult.getData() : null);
         }
         return new ExecutionResultImpl(results, executionContext.getErrors());
     }

--- a/src/test/groovy/graphql/HelloWorld.java
+++ b/src/test/groovy/graphql/HelloWorld.java
@@ -27,7 +27,7 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
-        Map<String, Object> result = new GraphQL(schema).execute("{hello}").getData();
+        Map<String, Object> result = (Map<String, Object>)new GraphQL(schema).execute("{hello}").getData();
         System.out.println(result);
     }
 
@@ -45,7 +45,7 @@ public class HelloWorld {
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(queryType)
                 .build();
-        Map<String, Object> result = new GraphQL(schema).execute("{hello}").getData();
+        Map<String, Object> result = (Map<String, Object>)new GraphQL(schema).execute("{hello}").getData();
         assertEquals("world", result.get("hello"));
     }
 }


### PR DESCRIPTION
Use ExecutionResults for resolveField (and its protected calls) to allow greater customization (necessary for rx to be able to stay inside the monad while resolving fields as much as possible)