### PR TITLE
Allow providing additional types to schema build.

### DIFF
--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -5,10 +5,12 @@ import static graphql.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import graphql.Assert;
 import graphql.Directives;
 
 public class GraphQLSchema {
@@ -19,7 +21,7 @@ public class GraphQLSchema {
     private Set<GraphQLType> dictionary;
 
     public GraphQLSchema(GraphQLObjectType queryType) {
-        this(queryType, null, null);
+        this(queryType, null, Collections.<GraphQLType>emptySet());
     }
 
     public Set<GraphQLType> getDictionary() {
@@ -27,6 +29,7 @@ public class GraphQLSchema {
     }
 
     public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, Set<GraphQLType> dictionary) {
+        assertNotNull(dictionary, "dictionary can't be null");
         assertNotNull(queryType, "queryType can't be null");
         this.queryType = queryType;
         this.mutationType = mutationType;
@@ -86,10 +89,11 @@ public class GraphQLSchema {
         }
 
         public GraphQLSchema build() {
-          return build(null);
+          return build(Collections.<GraphQLType>emptySet());
       }
 
         public GraphQLSchema build(Set<GraphQLType> dictionary) {
+          Assert.assertNotNull(dictionary, "dictionary can't be null");
           GraphQLSchema graphQLSchema = new GraphQLSchema(queryType, mutationType, dictionary);
           new SchemaUtil().replaceTypeReferences(graphQLSchema);
           return graphQLSchema;

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -1,31 +1,37 @@
 package graphql.schema;
 
 
-import graphql.Directives;
+import static graphql.Assert.assertNotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static graphql.Assert.assertNotNull;
+import graphql.Directives;
 
 public class GraphQLSchema {
 
     private final GraphQLObjectType queryType;
     private final GraphQLObjectType mutationType;
     private final Map<String, GraphQLType> typeMap;
+    private Set<GraphQLType> dictionary;
 
     public GraphQLSchema(GraphQLObjectType queryType) {
-        this(queryType, null);
+        this(queryType, null, null);
     }
 
+    public Set<GraphQLType> getDictionary() {
+      return dictionary;
+    }
 
-    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType) {
+    public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, Set<GraphQLType> dictionary) {
         assertNotNull(queryType, "queryType can't be null");
         this.queryType = queryType;
         this.mutationType = mutationType;
-        typeMap = new SchemaUtil().allTypes(this);
+        this.dictionary = dictionary;
+        typeMap = new SchemaUtil().allTypes(this, dictionary);
     }
 
     public GraphQLType getType(String typeName) {
@@ -80,11 +86,16 @@ public class GraphQLSchema {
         }
 
         public GraphQLSchema build() {
-            GraphQLSchema graphQLSchema = new GraphQLSchema(queryType, mutationType);
-            new SchemaUtil().replaceTypeReferences(graphQLSchema);
-            return graphQLSchema;
-        }
+          return build(null);
+      }
+
+        public GraphQLSchema build(Set<GraphQLType> dictionary) {
+          GraphQLSchema graphQLSchema = new GraphQLSchema(queryType, mutationType, dictionary);
+          new SchemaUtil().replaceTypeReferences(graphQLSchema);
+          return graphQLSchema;
+      }
 
 
     }
+
 }

--- a/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
@@ -11,7 +11,7 @@ class SchemaUtilTest extends Specification {
 
     def "collectAllTypes"() {
         when:
-        Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema)
+        Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema, null)
         then:
         types == [(droidType.name)                 : droidType,
                   (humanType.name)                 : humanType,

--- a/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
+++ b/src/test/groovy/graphql/schema/SchemaUtilTest.groovy
@@ -3,6 +3,8 @@ package graphql.schema
 import graphql.introspection.Introspection
 import spock.lang.Specification
 
+import java.util.Collections;
+
 import static graphql.Scalars.GraphQLBoolean
 import static graphql.Scalars.GraphQLString
 import static graphql.StarWarsSchema.*
@@ -11,7 +13,7 @@ class SchemaUtilTest extends Specification {
 
     def "collectAllTypes"() {
         when:
-        Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema, null)
+        Map<String, GraphQLType> types = new SchemaUtil().allTypes(starWarsSchema, Collections.emptySet())
         then:
         types == [(droidType.name)                 : droidType,
                   (humanType.name)                 : humanType,


### PR DESCRIPTION
With the current API, only concrete instances which are registered somewhere from the query or mutation root are registered.  This makes writting tools to automatically generate types a PITA - specifically because you have to ensure there is at least one concrete instance of every type registered.

This change provides a way to pass a set of types into the schema when building it, which will be added into the set of available types when replacing type references.

An alternative could be to provide a resolver to GraphQLTypeReference, which would be used to resolve the type at build time - however, this method seems far less intrusive for existing consumers :-)