### PR TITLE
Fix example for GraphQLUnionType

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ GraphQLInterfaceType comicCharacter = newInterface()
 
 Example: (a snippet from [here](src/test/groovy/graphql/GarfieldSchema.java))
 ```java
-PetType = GraphQLUnionType.newUnionType()
+GraphQLUnionType PetType = newUnionType()
     .name("Pet")
     .possibleType(CatType)
     .possibleType(DogType)

--- a/src/test/groovy/graphql/GarfieldSchema.java
+++ b/src/test/groovy/graphql/GarfieldSchema.java
@@ -13,6 +13,7 @@ import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLObjectType.newObject;
+import static graphql.schema.GraphQLUnionType.newUnionType;
 
 public class GarfieldSchema {
 
@@ -149,7 +150,7 @@ public class GarfieldSchema {
             .withInterface(NamedType)
             .build();
 
-    public static GraphQLUnionType PetType = GraphQLUnionType.newUnionType()
+    public static GraphQLUnionType PetType = newUnionType()
             .name("Pet")
             .possibleType(CatType)
             .possibleType(DogType)


### PR DESCRIPTION
Also, static import `newUnionType` method in `GarfieldSchema.java` to make it consistent with the example and other imports in GarfieldSchema.