### PR TITLE
Fix NPE when non-required input fields are missing

### DIFF
--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -84,8 +84,14 @@ public class ValuesResolver {
     private Object coerceValueForInputObjectField(GraphQLInputObjectType inputObjectType, Map<String, Object> input) {
         Map<String, Object> result = new LinkedHashMap<>();
         for (GraphQLInputObjectField inputField : inputObjectType.getFields()) {
-            Object value = coerceValue(inputField.getType(), input.get(inputField.getName()));
-            result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
+            Object inputValueForField = input.get(inputField.getName());
+            // Only set input if users explicitly specify the field
+            if (inputValueForField != null) {
+                Object value = coerceValue(inputField.getType(), inputValueForField);
+                result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
+            } else if (inputValueForField == null && inputField.getType() instanceof GraphQLNonNull) {
+                throw new GraphQLException(inputField.getName() + " is a required field but doesn't have value");
+            }
 
         }
         return result;


### PR DESCRIPTION
There're two fixes in this pull request:

1/ If you don't send all non-required input fields for an input object, it'll throw exception. This fix would just ignore non-required input fields if they're missing
2/ Validate required fields in input object