### PR TITLE
Change sourceCompatibility to 1.6.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.6
 def releaseVersion = System.properties.RELEASE_VERSION
 version = releaseVersion ? releaseVersion : new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date())
 group = 'com.graphql-java'

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class ExecutionResultImpl implements ExecutionResult {
 
-    private final List<GraphQLError> errors = new ArrayList<>();
+    private final List<GraphQLError> errors = new ArrayList<GraphQLError>();
     private Object data;
 
     public ExecutionResultImpl(List<? extends GraphQLError> errors) {
@@ -37,7 +37,7 @@ public class ExecutionResultImpl implements ExecutionResult {
 
     @Override
     public List<GraphQLError> getErrors() {
-        return new ArrayList<>(errors);
+        return new ArrayList<GraphQLError>(errors);
     }
 
 

--- a/src/main/java/graphql/InvalidSyntaxError.java
+++ b/src/main/java/graphql/InvalidSyntaxError.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class InvalidSyntaxError implements GraphQLError {
 
-    private final List<SourceLocation> sourceLocations = new ArrayList<>();
+    private final List<SourceLocation> sourceLocations = new ArrayList<SourceLocation>();
 
     public InvalidSyntaxError(SourceLocation sourceLocation) {
         if (sourceLocation != null)

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -51,7 +51,7 @@ public class Execution {
             OperationDefinition operationDefinition) {
         GraphQLObjectType operationRootType = getOperationRootType(executionContext.getGraphQLSchema(), executionContext.getOperationDefinition());
 
-        Map<String, List<Field>> fields = new LinkedHashMap<>();
+        Map<String, List<Field>> fields = new LinkedHashMap<String, List<Field>>();
         fieldCollector.collectFields(executionContext, operationRootType, operationDefinition.getSelectionSet(), new ArrayList<String>(), fields);
 
         if (operationDefinition.getOperation() == OperationDefinition.Operation.MUTATION) {

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -15,11 +15,11 @@ public class ExecutionContext {
 
     private GraphQLSchema graphQLSchema;
     private ExecutionStrategy executionStrategy;
-    private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
+    private Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
     private OperationDefinition operationDefinition;
-    private Map<String, Object> variables = new LinkedHashMap<>();
+    private Map<String, Object> variables = new LinkedHashMap<String, Object>();
     private Object root;
-    private List<GraphQLError> errors = new ArrayList<>();
+    private List<GraphQLError> errors = new ArrayList<GraphQLError>();
 
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -19,8 +19,8 @@ public class ExecutionContextBuilder {
     }
 
     public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
-        Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
-        Map<String, OperationDefinition> operationsByName = new LinkedHashMap<>();
+        Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<String, FragmentDefinition>();
+        Map<String, OperationDefinition> operationsByName = new LinkedHashMap<String, OperationDefinition>();
 
         for (Definition definition : document.getDefinitions()) {
             if (definition instanceof OperationDefinition) {

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -76,8 +76,8 @@ public abstract class ExecutionStrategy {
             resolvedType = (GraphQLObjectType) fieldType;
         }
 
-        Map<String, List<Field>> subFields = new LinkedHashMap<>();
-        List<String> visitedFragments = new ArrayList<>();
+        Map<String, List<Field>> subFields = new LinkedHashMap<String, List<Field>>();
+        List<String> visitedFragments = new ArrayList<String>();
         for (Field field : fields) {
             if (field.getSelectionSet() == null) continue;
             fieldCollector.collectFields(executionContext, resolvedType, field.getSelectionSet(), visitedFragments, subFields);
@@ -123,7 +123,7 @@ public abstract class ExecutionStrategy {
     }
 
     protected ExecutionResult completeValueForList(ExecutionContext executionContext, GraphQLList fieldType, List<Field> fields, List<Object> result) {
-        List<Object> completedResults = new ArrayList<>();
+        List<Object> completedResults = new ArrayList<Object>();
         for (Object item : result) {
             ExecutionResult completedValue = completeValue(executionContext, fieldType.getWrappedType(), fields, item);
             completedResults.add(completedValue != null ? completedValue.getData() : null);

--- a/src/main/java/graphql/execution/SimpleExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SimpleExecutionStrategy.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class SimpleExecutionStrategy extends ExecutionStrategy {
     @Override
     public ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
-        Map<String, Object> results = new LinkedHashMap<>();
+        Map<String, Object> results = new LinkedHashMap<String, Object>();
         for (String fieldName : fields.keySet()) {
             List<Field> fieldList = fields.get(fieldName);
             ExecutionResult resolvedResult = resolveField(executionContext, parentType, source, fieldList);

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -11,7 +11,7 @@ public class ValuesResolver {
 
 
     public Map<String, Object> getVariableValues(GraphQLSchema schema, List<VariableDefinition> variableDefinitions, Map<String, Object> inputs) {
-        Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
         for (VariableDefinition variableDefinition : variableDefinitions) {
             result.put(variableDefinition.getName(), getVariableValue(schema, variableDefinition, inputs.get(variableDefinition.getName())));
         }
@@ -20,7 +20,7 @@ public class ValuesResolver {
 
 
     public Map<String, Object> getArgumentValues(List<GraphQLArgument> argumentTypes, List<Argument> arguments, Map<String, Object> variables) {
-        Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
         Map<String, Argument> argumentMap = argumentMap(arguments);
         for (GraphQLArgument fieldArgument : argumentTypes) {
             Argument argument = argumentMap.get(fieldArgument.getName());
@@ -37,7 +37,7 @@ public class ValuesResolver {
 
 
     private Map<String, Argument> argumentMap(List<Argument> arguments) {
-        Map<String, Argument> result = new LinkedHashMap<>();
+        Map<String, Argument> result = new LinkedHashMap<String, Argument>();
         for (Argument argument : arguments) {
             result.put(argument.getName(), argument);
         }
@@ -82,7 +82,7 @@ public class ValuesResolver {
     }
 
     private Object coerceValueForInputObjectField(GraphQLInputObjectType inputObjectType, Map<String, Object> input) {
-        Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
         for (GraphQLInputObjectField inputField : inputObjectType.getFields()) {
             Object value = coerceValue(inputField.getType(), input.get(inputField.getName()));
             result.put(inputField.getName(), value == null ? inputField.getDefaultValue() : value);
@@ -101,7 +101,7 @@ public class ValuesResolver {
 
     private List coerceValueForList(GraphQLList graphQLList, Object value) {
         if (value instanceof Iterable) {
-            List<Object> result = new ArrayList<>();
+            List<Object> result = new ArrayList<Object>();
             for (Object val : (Iterable) value) {
                 result.add(coerceValue(graphQLList.getWrappedType(), val));
             }
@@ -136,7 +136,7 @@ public class ValuesResolver {
     private Object coerceValueAstForList(GraphQLList graphQLList, Value value, Map<String, Object> variables) {
         if (value instanceof ArrayValue) {
             ArrayValue arrayValue = (ArrayValue) value;
-            List<Object> result = new ArrayList<>();
+            List<Object> result = new ArrayList<Object>();
             for (Value singleValue : arrayValue.getValues()) {
                 result.add(coerceValueAst(graphQLList.getWrappedType(), singleValue, variables));
             }
@@ -147,7 +147,7 @@ public class ValuesResolver {
     }
 
     private Object coerceValueAstForInputObject(GraphQLInputObjectType type, ObjectValue inputValue, Map<String, Object> variables) {
-        Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
 
         for (ObjectField objectField : inputValue.getObjectFields()) {
             GraphQLInputObjectField inputObjectField = type.getField(objectField.getName());

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -19,9 +19,9 @@ import static java.util.Collections.singletonList;
  * Execution Strategy that minimizes calls to the data fetcher when used in conjunction with {@link DataFetcher}s that have
  * {@link DataFetcher#get(DataFetchingEnvironment)} methods annotated with {@link Batched}. See the javadoc comment on
  * {@link Batched} for a more detailed description of batched data fetchers.
- * <p/>
+ * <p>
  * The strategy runs a BFS over terms of the query and passes a list of all the relevant sources to the batched data fetcher.
- * <p/>
+ * <p>
  * Normal DataFetchers can be used, however they will not see benefits of batching as they expect a single source object
  * at a time.
  */
@@ -40,7 +40,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     private ExecutionResult execute(ExecutionContext executionContext, GraphQLExecutionNode root) {
 
-        Queue<GraphQLExecutionNode> nodes = new ArrayDeque<>();
+        Queue<GraphQLExecutionNode> nodes = new ArrayDeque<GraphQLExecutionNode>();
         nodes.add(root);
 
         while (!nodes.isEmpty()) {
@@ -104,7 +104,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
                                                   List<GraphQLExecutionNodeValue> values, String fieldName, List<Field> fields,
                                                   GraphQLObjectType parentType, GraphQLList listType) {
 
-        List<GraphQLExecutionNodeValue> flattenedNodeValues = new ArrayList<>();
+        List<GraphQLExecutionNodeValue> flattenedNodeValues = new ArrayList<GraphQLExecutionNodeValue>();
 
         for (GraphQLExecutionNodeValue value : values) {
             if (value.getValue() == null) {
@@ -137,7 +137,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     private List<GraphQLExecutionNode> createChildNodes(ExecutionContext executionContext, List<Field> fields,
                                                         ChildDataCollector collector) {
 
-        List<GraphQLExecutionNode> childNodes = new ArrayList<>();
+        List<GraphQLExecutionNode> childNodes = new ArrayList<GraphQLExecutionNode>();
 
         for (ChildDataCollector.Entry entry : collector.getEntries()) {
             Map<String, List<Field>> childFields = getChildFields(executionContext, entry.getObjectType(), fields);
@@ -185,8 +185,8 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
     private Map<String, List<Field>> getChildFields(ExecutionContext executionContext, GraphQLObjectType resolvedType,
                                                     List<Field> fields) {
 
-        Map<String, List<Field>> subFields = new LinkedHashMap<>();
-        List<String> visitedFragments = new ArrayList<>();
+        Map<String, List<Field>> subFields = new LinkedHashMap<String, List<Field>>();
+        List<String> visitedFragments = new ArrayList<String>();
         for (Field field : fields) {
             if (field.getSelectionSet() == null) continue;
             fieldCollector.collectFields(executionContext, resolvedType, field.getSelectionSet(), visitedFragments, subFields);
@@ -242,7 +242,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
         Map<String, Object> argumentValues = valuesResolver.getArgumentValues(
                 fieldDef.getArguments(), fields.get(0).getArguments(), executionContext.getVariables());
-        List<Object> sources = new ArrayList<>();
+        List<Object> sources = new ArrayList<Object>();
         for (GraphQLExecutionNodeDatum n : nodeData) {
             sources.add(n.getSource());
         }
@@ -260,7 +260,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         try {
             values = (List<Object>) getDataFetcher(fieldDef).get(environment);
         } catch (Exception e) {
-            values = new ArrayList<>();
+            values = new ArrayList<Object>();
             for (int i = 0; i < nodeData.size(); i++) {
                 values.add(null);
             }
@@ -269,7 +269,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
         }
         assert nodeData.size() == values.size();
 
-        List<GraphQLExecutionNodeValue> retVal = new ArrayList<>();
+        List<GraphQLExecutionNodeValue> retVal = new ArrayList<GraphQLExecutionNodeValue>();
         for (int i = 0; i < nodeData.size(); i++) {
             retVal.add(new GraphQLExecutionNodeValue(nodeData.get(i), values.get(i)));
         }

--- a/src/main/java/graphql/execution/batched/ChildDataCollector.java
+++ b/src/main/java/graphql/execution/batched/ChildDataCollector.java
@@ -9,8 +9,8 @@ import java.util.Map;
 
 public class ChildDataCollector {
 
-    private final Map<String, List<GraphQLExecutionNodeDatum>> childDataByTypename = new HashMap<>();
-    private final Map<String, GraphQLObjectType> childTypesByName = new HashMap<>();
+    private final Map<String, List<GraphQLExecutionNodeDatum>> childDataByTypename = new HashMap<String, List<GraphQLExecutionNodeDatum>>();
+    private final Map<String, GraphQLObjectType> childTypesByName = new HashMap<String, GraphQLObjectType>();
 
 
     public void putChildData(GraphQLObjectType objectType, GraphQLExecutionNodeDatum datum) {
@@ -35,7 +35,7 @@ public class ChildDataCollector {
     }
 
     public List<Entry> getEntries() {
-        List<Entry> entries = new ArrayList<>();
+        List<Entry> entries = new ArrayList<Entry>();
         for (String childTypename: childTypesByName.keySet()) {
             GraphQLObjectType childType = childTypesByName.get(childTypename);
             List<GraphQLExecutionNodeDatum> childData = multimapGet(childDataByTypename, childTypename);

--- a/src/main/java/graphql/execution/batched/GraphQLExecutionResultContainer.java
+++ b/src/main/java/graphql/execution/batched/GraphQLExecutionResultContainer.java
@@ -11,13 +11,13 @@ public abstract class GraphQLExecutionResultContainer {
      * Creates a child datum which is linked through the results container to this parent.
      */
     public GraphQLExecutionNodeDatum createAndPutChildDatum(String fieldName, Object value) {
-        Map<String,Object> map = new HashMap<>();
+        Map<String,Object> map = new HashMap<String, Object>();
         putResult(fieldName, map);
         return new GraphQLExecutionNodeDatum(map, value);
     }
 
     public GraphQLExecutionResultList createAndPutEmptyChildList(String fieldName) {
-        List<Object> resultList = new ArrayList<>();
+        List<Object> resultList = new ArrayList<Object>();
         putResult(fieldName, resultList);
         return new GraphQLExecutionResultList(resultList);
     }

--- a/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
+++ b/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
@@ -26,7 +26,7 @@ public class UnbatchedDataFetcher implements BatchedDataFetcher {
     public Object get(DataFetchingEnvironment environment) {
         @SuppressWarnings("unchecked")
         List<Object> sources = (List<Object>) environment.getSource();
-        List<Object> results = new ArrayList<>();
+        List<Object> results = new ArrayList<Object>();
         for (Object source: sources) {
             DataFetchingEnvironment singleEnv = new DataFetchingEnvironment(
                     source,

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -177,7 +177,7 @@ public class Introspection {
                 GraphQLFieldsContainer fieldsContainer = (GraphQLFieldsContainer) type;
                 List<GraphQLFieldDefinition> fieldDefinitions = fieldsContainer.getFieldDefinitions();
                 if (includeDeprecated) return fieldDefinitions;
-                List<GraphQLFieldDefinition> filtered = new ArrayList<>(fieldDefinitions);
+                List<GraphQLFieldDefinition> filtered = new ArrayList<GraphQLFieldDefinition>(fieldDefinitions);
                 for (GraphQLFieldDefinition fieldDefinition : fieldDefinitions) {
                     if (fieldDefinition.isDeprecated()) filtered.remove(fieldDefinition);
                 }
@@ -220,7 +220,7 @@ public class Introspection {
             if (type instanceof GraphQLEnumType) {
                 List<GraphQLEnumValueDefinition> values = ((GraphQLEnumType) type).getValues();
                 if (includeDeprecated) return values;
-                List<GraphQLEnumValueDefinition> filtered = new ArrayList<>(values);
+                List<GraphQLEnumValueDefinition> filtered = new ArrayList<GraphQLEnumValueDefinition>(values);
                 for (GraphQLEnumValueDefinition valueDefinition : values) {
                     if (valueDefinition.isDeprecated()) filtered.remove(valueDefinition);
                 }

--- a/src/main/java/graphql/language/Argument.java
+++ b/src/main/java/graphql/language/Argument.java
@@ -33,7 +33,7 @@ public class Argument extends AbstractNode {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(value);
         return result;
     }

--- a/src/main/java/graphql/language/ArrayValue.java
+++ b/src/main/java/graphql/language/ArrayValue.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ArrayValue extends AbstractNode implements Value {
 
-    private List<Value> values = new ArrayList<>();
+    private List<Value> values = new ArrayList<Value>();
 
     public ArrayValue() {
     }

--- a/src/main/java/graphql/language/BooleanValue.java
+++ b/src/main/java/graphql/language/BooleanValue.java
@@ -23,7 +23,7 @@ public class BooleanValue extends AbstractNode implements Value {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/src/main/java/graphql/language/Directive.java
+++ b/src/main/java/graphql/language/Directive.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class Directive extends AbstractNode {
     private String name;
-    private final List<Argument> arguments = new ArrayList<>();
+    private final List<Argument> arguments = new ArrayList<Argument>();
 
     public Directive() {
 

--- a/src/main/java/graphql/language/Document.java
+++ b/src/main/java/graphql/language/Document.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class Document extends AbstractNode {
 
-    private List<Definition> definitions = new ArrayList<>();
+    private List<Definition> definitions = new ArrayList<Definition>();
 
     public Document() {
 

--- a/src/main/java/graphql/language/EnumValue.java
+++ b/src/main/java/graphql/language/EnumValue.java
@@ -23,7 +23,7 @@ public class EnumValue extends AbstractNode implements  Value {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -9,8 +9,8 @@ public class Field extends AbstractNode implements Selection {
     private String name;
     private String alias;
 
-    private List<Argument> arguments = new ArrayList<>();
-    private List<Directive> directives = new ArrayList<>();
+    private List<Argument> arguments = new ArrayList<Argument>();
+    private List<Directive> directives = new ArrayList<Directive>();
     private SelectionSet selectionSet;
 
     public Field() {

--- a/src/main/java/graphql/language/FloatValue.java
+++ b/src/main/java/graphql/language/FloatValue.java
@@ -24,7 +24,7 @@ public class FloatValue extends AbstractNode implements Value {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -8,7 +8,7 @@ public class FragmentDefinition extends AbstractNode implements Definition {
 
     private String name;
     private TypeName typeCondition;
-    private List<Directive> directives = new ArrayList<>();
+    private List<Directive> directives = new ArrayList<Directive>();
     private SelectionSet selectionSet;
 
     public FragmentDefinition() {
@@ -61,7 +61,7 @@ public class FragmentDefinition extends AbstractNode implements Definition {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(typeCondition);
         result.addAll(directives);
         result.add(selectionSet);

--- a/src/main/java/graphql/language/FragmentSpread.java
+++ b/src/main/java/graphql/language/FragmentSpread.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class FragmentSpread extends AbstractNode implements Selection {
 
     private String name;
-    private List<Directive> directives = new ArrayList<>();
+    private List<Directive> directives = new ArrayList<Directive>();
 
     public FragmentSpread() {
     }
@@ -46,7 +46,7 @@ public class FragmentSpread extends AbstractNode implements Selection {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.addAll(directives);
         return result;
     }

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class InlineFragment extends AbstractNode implements Selection {
     private TypeName typeCondition;
-    private List<Directive> directives = new ArrayList<>();
+    private List<Directive> directives = new ArrayList<Directive>();
     private SelectionSet selectionSet;
 
     public InlineFragment() {
@@ -55,7 +55,7 @@ public class InlineFragment extends AbstractNode implements Selection {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(typeCondition);
         result.addAll(directives);
         result.add(selectionSet);

--- a/src/main/java/graphql/language/IntValue.java
+++ b/src/main/java/graphql/language/IntValue.java
@@ -22,7 +22,7 @@ public class IntValue extends AbstractNode implements Value {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/src/main/java/graphql/language/ListType.java
+++ b/src/main/java/graphql/language/ListType.java
@@ -25,7 +25,7 @@ public class ListType extends AbstractNode implements Type {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(type);
         return result;
     }

--- a/src/main/java/graphql/language/NonNullType.java
+++ b/src/main/java/graphql/language/NonNullType.java
@@ -29,7 +29,7 @@ public class NonNullType extends AbstractNode implements Type {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(type);
         return result;
     }

--- a/src/main/java/graphql/language/ObjectField.java
+++ b/src/main/java/graphql/language/ObjectField.java
@@ -24,7 +24,7 @@ public class ObjectField extends AbstractNode {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(value);
         return result;
     }

--- a/src/main/java/graphql/language/ObjectValue.java
+++ b/src/main/java/graphql/language/ObjectValue.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ObjectValue extends AbstractNode implements Value {
 
-    private List<ObjectField> objectFields = new ArrayList<>();
+    private List<ObjectField> objectFields = new ArrayList<ObjectField>();
 
     public ObjectValue() {
     }
@@ -21,7 +21,7 @@ public class ObjectValue extends AbstractNode implements Value {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.addAll(objectFields);
         return result;
     }

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -13,8 +13,8 @@ public class OperationDefinition extends AbstractNode implements Definition {
     private String name;
 
     private Operation operation;
-    private List<VariableDefinition> variableDefinitions = new ArrayList<>();
-    private List<Directive> directives = new ArrayList<>();
+    private List<VariableDefinition> variableDefinitions = new ArrayList<VariableDefinition>();
+    private List<Directive> directives = new ArrayList<Directive>();
     private SelectionSet selectionSet;
 
     public OperationDefinition() {
@@ -44,7 +44,7 @@ public class OperationDefinition extends AbstractNode implements Definition {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.addAll(variableDefinitions);
         result.addAll(directives);
         result.add(selectionSet);

--- a/src/main/java/graphql/language/SelectionSet.java
+++ b/src/main/java/graphql/language/SelectionSet.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class SelectionSet extends AbstractNode{
 
-    private final List<Selection> selections = new ArrayList<>();
+    private final List<Selection> selections = new ArrayList<Selection>();
 
     public List<Selection> getSelections() {
         return selections;
@@ -21,7 +21,7 @@ public class SelectionSet extends AbstractNode{
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.addAll(selections);
         return result;
     }

--- a/src/main/java/graphql/language/StringValue.java
+++ b/src/main/java/graphql/language/StringValue.java
@@ -22,7 +22,7 @@ public class StringValue extends AbstractNode implements Value {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         return result;
     }
 

--- a/src/main/java/graphql/language/TypeName.java
+++ b/src/main/java/graphql/language/TypeName.java
@@ -22,7 +22,7 @@ public class TypeName extends AbstractNode implements Type {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/src/main/java/graphql/language/VariableDefinition.java
+++ b/src/main/java/graphql/language/VariableDefinition.java
@@ -52,7 +52,7 @@ public class VariableDefinition extends AbstractNode {
 
     @Override
     public List<Node> getChildren() {
-        List<Node> result = new ArrayList<>();
+        List<Node> result = new ArrayList<Node>();
         result.add(type);
         if (defaultValue != null) result.add(defaultValue);
         return result;

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -22,7 +22,7 @@ public class VariableReference extends AbstractNode implements Value {
 
     @Override
     public List<Node> getChildren() {
-        return new ArrayList<>();
+        return new ArrayList<Node>();
     }
 
     @Override

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -38,7 +38,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         }
     }
 
-    private Deque<ContextEntry> contextStack = new ArrayDeque<>();
+    private Deque<ContextEntry> contextStack = new ArrayDeque<ContextEntry>();
 
 
     private void addContextProperty(ContextProperty contextProperty, Object value) {

--- a/src/main/java/graphql/relay/Connection.java
+++ b/src/main/java/graphql/relay/Connection.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Connection {
-    private List<Edge> edges =  new ArrayList<>();
+    private List<Edge> edges =  new ArrayList<Edge>();
 
     private PageInfo pageInfo;
 

--- a/src/main/java/graphql/relay/Relay.java
+++ b/src/main/java/graphql/relay/Relay.java
@@ -71,7 +71,7 @@ public class Relay {
     }
 
     public List<GraphQLArgument> getConnectionFieldArguments() {
-        List<GraphQLArgument> args = new ArrayList<>();
+        List<GraphQLArgument> args = new ArrayList<GraphQLArgument>();
 
         args.add(newArgument()
                 .name("before")
@@ -93,7 +93,7 @@ public class Relay {
     }
     
     public List<GraphQLArgument> getBackwardPaginationConnectionFieldArguments() {
-        List<GraphQLArgument> args = new ArrayList<>();
+        List<GraphQLArgument> args = new ArrayList<GraphQLArgument>();
 
         args.add(newArgument()
                 .name("before")
@@ -107,7 +107,7 @@ public class Relay {
     }
     
     public List<GraphQLArgument> getForwardPaginationConnectionFieldArguments() {
-        List<GraphQLArgument> args = new ArrayList<>();
+        List<GraphQLArgument> args = new ArrayList<GraphQLArgument>();
 
         args.add(newArgument()
                 .name("after")

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class SimpleListConnection implements DataFetcher {
 
     private static final String DUMMY_CURSOR_PREFIX = "simple-cursor";
-    private List<?> data = new ArrayList<>();
+    private List<?> data = new ArrayList<Object>();
 
 
     public SimpleListConnection(List<?> data) {
@@ -19,7 +19,7 @@ public class SimpleListConnection implements DataFetcher {
     }
 
     private List<Edge> buildEdges() {
-        List<Edge> edges = new ArrayList<>();
+        List<Edge> edges = new ArrayList<Edge>();
         int ix = 0;
         for (Object object : data) {
             edges.add(new Edge(object, new ConnectionCursor(createCursor(ix++))));

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -10,7 +10,7 @@ public class GraphQLDirective {
 
     private final String name;
     private final String description;
-    private final List<GraphQLArgument> arguments = new ArrayList<>();
+    private final List<GraphQLArgument> arguments = new ArrayList<GraphQLArgument>();
     private final boolean onOperation;
     private final boolean onFragment;
     private final boolean onField;
@@ -31,7 +31,7 @@ public class GraphQLDirective {
     }
 
     public List<GraphQLArgument> getArguments() {
-        return new ArrayList<>(arguments);
+        return new ArrayList<GraphQLArgument>(arguments);
     }
 
     public GraphQLArgument getArgument(String name) {
@@ -64,7 +64,7 @@ public class GraphQLDirective {
     public static class Builder {
 
         private String name;
-        private final List<GraphQLArgument> arguments = new ArrayList<>();
+        private final List<GraphQLArgument> arguments = new ArrayList<GraphQLArgument>();
         private String description;
         private boolean onOperation;
         private boolean onFragment;

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -14,7 +14,7 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
 
     private final String name;
     private final String description;
-    private final Map<String, GraphQLEnumValueDefinition> valueDefinitionMap = new LinkedHashMap<>();
+    private final Map<String, GraphQLEnumValueDefinition> valueDefinitionMap = new LinkedHashMap<String, GraphQLEnumValueDefinition>();
 
     private final Coercing coercing = new Coercing() {
         @Override
@@ -51,7 +51,7 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
     }
 
     public List<GraphQLEnumValueDefinition> getValues() {
-        return new ArrayList<>(valueDefinitionMap.values());
+        return new ArrayList<GraphQLEnumValueDefinition>(valueDefinitionMap.values());
     }
 
 
@@ -89,7 +89,7 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
 
         private String name;
         private String description;
-        private final List<GraphQLEnumValueDefinition> values = new ArrayList<>();
+        private final List<GraphQLEnumValueDefinition> values = new ArrayList<GraphQLEnumValueDefinition>();
 
         public Builder name(String name) {
             this.name = name;

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -14,7 +14,7 @@ public class GraphQLFieldDefinition {
     private GraphQLOutputType type;
     private final DataFetcher dataFetcher;
     private final String deprecationReason;
-    private final List<GraphQLArgument> arguments = new ArrayList<>();
+    private final List<GraphQLArgument> arguments = new ArrayList<GraphQLArgument>();
 
 
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
@@ -56,7 +56,7 @@ public class GraphQLFieldDefinition {
     }
 
     public List<GraphQLArgument> getArguments() {
-        return new ArrayList<>(arguments);
+        return new ArrayList<GraphQLArgument>(arguments);
     }
 
     public String getDescription() {
@@ -81,7 +81,7 @@ public class GraphQLFieldDefinition {
         private String description;
         private GraphQLOutputType type;
         private DataFetcher dataFetcher;
-        private List<GraphQLArgument> arguments = new ArrayList<>();
+        private List<GraphQLArgument> arguments = new ArrayList<GraphQLArgument>();
         private String deprecationReason;
         private boolean isField;
 

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -14,7 +14,7 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
     private final String description;
 
 
-    private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<>();
+    private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<String, GraphQLInputObjectField>();
 
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields) {
         assertNotNull(name, "name can't be null");
@@ -39,7 +39,7 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
     }
 
     public List<GraphQLInputObjectField> getFields() {
-        return new ArrayList<>(fieldMap.values());
+        return new ArrayList<GraphQLInputObjectField>(fieldMap.values());
     }
 
     public GraphQLInputObjectField getField(String name) {
@@ -53,7 +53,7 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
     public static class Builder {
         private String name;
         private String description;
-        private List<GraphQLInputObjectField> fields = new ArrayList<>();
+        private List<GraphQLInputObjectField> fields = new ArrayList<GraphQLInputObjectField>();
 
         public Builder name(String name) {
             this.name = name;

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -12,7 +12,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
 
     private final String name;
     private final String description;
-    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
+    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<String, GraphQLFieldDefinition>();
     private final TypeResolver typeResolver;
 
     public GraphQLInterfaceType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, TypeResolver typeResolver) {
@@ -37,7 +37,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
 
 
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
-        return new ArrayList<>(fieldDefinitionsByName.values());
+        return new ArrayList<GraphQLFieldDefinition>(fieldDefinitionsByName.values());
     }
 
     public String getName() {
@@ -70,7 +70,7 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
     public static class Builder {
         private String name;
         private String description;
-        private List<GraphQLFieldDefinition> fields = new ArrayList<>();
+        private List<GraphQLFieldDefinition> fields = new ArrayList<GraphQLFieldDefinition>();
         private TypeResolver typeResolver;
 
 

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -12,8 +12,8 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
     private final String name;
     private final String description;
-    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
-    private final List<GraphQLInterfaceType> interfaces = new ArrayList<>();
+    private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<String, GraphQLFieldDefinition>();
+    private final List<GraphQLInterfaceType> interfaces = new ArrayList<GraphQLInterfaceType>();
 
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, List<GraphQLInterfaceType> interfaces) {
         assertNotNull(name, "name can't null");
@@ -38,12 +38,12 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
 
 
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
-        return new ArrayList<>(fieldDefinitionsByName.values());
+        return new ArrayList<GraphQLFieldDefinition>(fieldDefinitionsByName.values());
     }
 
 
     public List<GraphQLInterfaceType> getInterfaces() {
-        return new ArrayList<>(interfaces);
+        return new ArrayList<GraphQLInterfaceType>(interfaces);
     }
 
     public String getDescription() {
@@ -74,8 +74,8 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
     public static class Builder {
         private String name;
         private String description;
-        private List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<>();
-        private List<GraphQLInterfaceType> interfaces = new ArrayList<>();
+        private List<GraphQLFieldDefinition> fieldDefinitions = new ArrayList<GraphQLFieldDefinition>();
+        private List<GraphQLInterfaceType> interfaces = new ArrayList<GraphQLInterfaceType>();
 
         public Builder name(String name) {
             this.name = name;

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -42,7 +42,7 @@ public class GraphQLSchema {
     }
 
     public List<GraphQLType> getAllTypesAsList() {
-        return new ArrayList<>(typeMap.values());
+        return new ArrayList<GraphQLType>(typeMap.values());
     }
 
     public GraphQLObjectType getQueryType() {

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -10,7 +10,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
 
     private final String name;
     private final String description;
-    private List<GraphQLType> types = new ArrayList<>();
+    private List<GraphQLType> types = new ArrayList<GraphQLType>();
     private final TypeResolver typeResolver;
 
 
@@ -26,7 +26,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
 
 
     public List<GraphQLType> getTypes() {
-        return new ArrayList<>(types);
+        return new ArrayList<GraphQLType>(types);
     }
 
     public TypeResolver getTypeResolver() {
@@ -49,7 +49,7 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
     public static class Builder {
         private String name;
         private String description;
-        private List<GraphQLType> types = new ArrayList<>();
+        private List<GraphQLType> types = new ArrayList<GraphQLType>();
         private TypeResolver typeResolver;
 
         public Builder name(String name) {

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -34,7 +34,9 @@ public class PropertyDataFetcher implements DataFetcher {
 
         } catch (NoSuchMethodException e) {
             return null;
-        } catch (IllegalAccessException | InvocationTargetException e) {
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -106,7 +106,7 @@ public class SchemaUtil {
 
 
     public Map<String, GraphQLType> allTypes(GraphQLSchema schema,  Set<GraphQLType> dictionary) {
-        Map<String, GraphQLType> typesByName = new LinkedHashMap<>();
+        Map<String, GraphQLType> typesByName = new LinkedHashMap<String, GraphQLType>();
         collectTypes(schema.getQueryType(), typesByName);
         if (schema.isSupportingMutations()) {
             collectTypes(schema.getMutationType(), typesByName);
@@ -122,7 +122,7 @@ public class SchemaUtil {
 
     public List<GraphQLObjectType> findImplementations(GraphQLSchema schema, GraphQLInterfaceType interfaceType) {
         Map<String, GraphQLType> allTypes = allTypes(schema, schema.getDictionary());
-        List<GraphQLObjectType> result = new ArrayList<>();
+        List<GraphQLObjectType> result = new ArrayList<GraphQLObjectType>();
         for (GraphQLType type : allTypes.values()) {
             if (!(type instanceof GraphQLObjectType)) {
                 continue;
@@ -167,7 +167,7 @@ public class SchemaUtil {
     }
 
     List<GraphQLType> resolveTypeReferences(List<GraphQLType> types, Map<String, GraphQLType> typeMap) {
-        List<GraphQLType> resolvedTypes = new ArrayList<>();
+        List<GraphQLType> resolvedTypes = new ArrayList<GraphQLType>();
         for (GraphQLType type : types) {
             resolvedTypes.add(resolveTypeReference(type, typeMap));
         }

--- a/src/main/java/graphql/validation/ErrorFactory.java
+++ b/src/main/java/graphql/validation/ErrorFactory.java
@@ -11,7 +11,7 @@ public class ErrorFactory {
 
 
     public ValidationError newError(ValidationErrorType validationErrorType, List<? extends Node> locations, String description) {
-        List<SourceLocation> locationList = new ArrayList<>();
+        List<SourceLocation> locationList = new ArrayList<SourceLocation>();
         for (Node node : locations) {
             locationList.add(node.getSourceLocation());
         }

--- a/src/main/java/graphql/validation/LanguageTraversal.java
+++ b/src/main/java/graphql/validation/LanguageTraversal.java
@@ -10,7 +10,7 @@ public class LanguageTraversal {
 
 
     public void traverse(Node root, QueryLanguageVisitor queryLanguageVisitor) {
-        List<Node> path = new ArrayList<>();
+        List<Node> path = new ArrayList<Node>();
         traverseImpl(root, queryLanguageVisitor, path);
     }
 

--- a/src/main/java/graphql/validation/RulesVisitor.java
+++ b/src/main/java/graphql/validation/RulesVisitor.java
@@ -7,12 +7,12 @@ import java.util.*;
 
 public class RulesVisitor implements QueryLanguageVisitor {
 
-    private final List<AbstractRule> rules = new ArrayList<>();
+    private final List<AbstractRule> rules = new ArrayList<AbstractRule>();
     private ValidationContext validationContext;
     private boolean subVisitor;
-    private List<AbstractRule> rulesVisitingFragmentSpreads = new ArrayList<>();
-    private Map<Node, List<AbstractRule>> rulesToSkipByUntilNode = new IdentityHashMap<>();
-    private Set<AbstractRule> rulesToSkip = new LinkedHashSet<>();
+    private List<AbstractRule> rulesVisitingFragmentSpreads = new ArrayList<AbstractRule>();
+    private Map<Node, List<AbstractRule>> rulesToSkipByUntilNode = new IdentityHashMap<Node, List<AbstractRule>>();
+    private Set<AbstractRule> rulesToSkip = new LinkedHashSet<AbstractRule>();
 
     public RulesVisitor(ValidationContext validationContext, List<AbstractRule> rules) {
         this(validationContext, rules, false);
@@ -38,9 +38,9 @@ public class RulesVisitor implements QueryLanguageVisitor {
     public void enter(Node node, List<Node> ancestors) {
 //        System.out.println("enter: " + node);
         validationContext.getTraversalContext().enter(node, ancestors);
-        Set<AbstractRule> tmpRulesSet = new LinkedHashSet<>(this.rules);
+        Set<AbstractRule> tmpRulesSet = new LinkedHashSet<AbstractRule>(this.rules);
         tmpRulesSet.removeAll(rulesToSkip);
-        List<AbstractRule> rulesToConsider = new ArrayList<>(tmpRulesSet);
+        List<AbstractRule> rulesToConsider = new ArrayList<AbstractRule>(tmpRulesSet);
         if (node instanceof Argument) {
             checkArgument((Argument) node, rulesToConsider);
         } else if (node instanceof TypeName) {
@@ -117,7 +117,7 @@ public class RulesVisitor implements QueryLanguageVisitor {
     }
 
     private List<AbstractRule> getRulesVisitingFragmentSpreads(List<AbstractRule> rules) {
-        List<AbstractRule> result = new ArrayList<>();
+        List<AbstractRule> result = new ArrayList<AbstractRule>();
         for (AbstractRule rule : rules) {
             if (rule.isVisitFragmentSpreads()) result.add(rule);
         }
@@ -127,7 +127,7 @@ public class RulesVisitor implements QueryLanguageVisitor {
 
     private void checkFragmentDefinition(FragmentDefinition fragmentDefinition, List<AbstractRule> rules) {
         if (!subVisitor) {
-            rulesToSkipByUntilNode.put(fragmentDefinition, new ArrayList<>(rulesVisitingFragmentSpreads));
+            rulesToSkipByUntilNode.put(fragmentDefinition, new ArrayList<AbstractRule>(rulesVisitingFragmentSpreads));
             rulesToSkip.addAll(rulesVisitingFragmentSpreads);
         }
 

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -13,10 +13,10 @@ import static graphql.introspection.Introspection.*;
 
 public class TraversalContext implements QueryLanguageVisitor {
     GraphQLSchema schema;
-    List<GraphQLOutputType> outputTypeStack = new ArrayList<>();
-    List<GraphQLCompositeType> parentTypeStack = new ArrayList<>();
-    List<GraphQLInputType> inputTypeStack = new ArrayList<>();
-    List<GraphQLFieldDefinition> fieldDefStack = new ArrayList<>();
+    List<GraphQLOutputType> outputTypeStack = new ArrayList<GraphQLOutputType>();
+    List<GraphQLCompositeType> parentTypeStack = new ArrayList<GraphQLCompositeType>();
+    List<GraphQLInputType> inputTypeStack = new ArrayList<GraphQLInputType>();
+    List<GraphQLFieldDefinition> fieldDefStack = new ArrayList<GraphQLFieldDefinition>();
     GraphQLDirective directive;
     GraphQLArgument argument;
 

--- a/src/main/java/graphql/validation/ValidationContext.java
+++ b/src/main/java/graphql/validation/ValidationContext.java
@@ -15,7 +15,7 @@ public class ValidationContext {
     private final Document document;
 
     private TraversalContext traversalContext;
-    private final Map<String, FragmentDefinition> fragmentDefinitionMap = new LinkedHashMap<>();
+    private final Map<String, FragmentDefinition> fragmentDefinitionMap = new LinkedHashMap<String, FragmentDefinition>();
 
 
     public ValidationContext(GraphQLSchema schema, Document document) {

--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -12,7 +12,7 @@ public class ValidationError implements GraphQLError {
 
 
     private final ValidationErrorType validationErrorType;
-    private final List<SourceLocation> sourceLocations = new ArrayList<>();
+    private final List<SourceLocation> sourceLocations = new ArrayList<SourceLocation>();
     private final String description;
 
     public ValidationError(ValidationErrorType validationErrorType) {

--- a/src/main/java/graphql/validation/ValidationErrorCollector.java
+++ b/src/main/java/graphql/validation/ValidationErrorCollector.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class ValidationErrorCollector {
 
-    private final List<ValidationError> errors = new ArrayList<>();
+    private final List<ValidationError> errors = new ArrayList<ValidationError>();
 
     public void addError(ValidationError validationError){
         this.errors.add(validationError);

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -74,7 +74,7 @@ public class ValidationUtil {
     }
 
     private Map<String, ObjectField> fieldMap(ObjectValue objectValue) {
-        Map<String, ObjectField> result = new LinkedHashMap<>();
+        Map<String, ObjectField> result = new LinkedHashMap<String, ObjectField>();
         for (ObjectField objectField : objectValue.getObjectFields()) {
             result.put(objectField.getName(), objectField);
         }

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -23,7 +23,7 @@ public class Validator {
     }
 
     private List<AbstractRule> createRules(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
-        List<AbstractRule> rules = new ArrayList<>();
+        List<AbstractRule> rules = new ArrayList<AbstractRule>();
         ArgumentsOfCorrectType argumentsOfCorrectType = new ArgumentsOfCorrectType(validationContext, validationErrorCollector);
         rules.add(argumentsOfCorrectType);
         VariableDefaultValuesOfCorrectType variableDefaultValuesOfCorrectType = new VariableDefaultValuesOfCorrectType(validationContext, validationErrorCollector);

--- a/src/main/java/graphql/validation/rules/NoFragmentCycles.java
+++ b/src/main/java/graphql/validation/rules/NoFragmentCycles.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class NoFragmentCycles extends AbstractRule {
 
-    private Map<String, List<FragmentSpread>> fragmentSpreads = new LinkedHashMap<>();
+    private Map<String, List<FragmentSpread>> fragmentSpreads = new LinkedHashMap<String, List<FragmentSpread>>();
 
 
     public NoFragmentCycles(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
@@ -34,7 +34,7 @@ public class NoFragmentCycles extends AbstractRule {
 
 
     private List<FragmentSpread> gatherSpreads(FragmentDefinition fragmentDefinition) {
-        final List<FragmentSpread> fragmentSpreads = new ArrayList<>();
+        final List<FragmentSpread> fragmentSpreads = new ArrayList<FragmentSpread>();
         QueryLanguageVisitor visitor = new QueryLanguageVisitor() {
             @Override
             public void enter(Node node, List<Node> path) {
@@ -56,7 +56,7 @@ public class NoFragmentCycles extends AbstractRule {
 
     @Override
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
-        List<FragmentSpread> spreadPath = new ArrayList<>();
+        List<FragmentSpread> spreadPath = new ArrayList<FragmentSpread>();
         detectCycleRecursive(fragmentDefinition.getName(), fragmentDefinition.getName(), spreadPath);
     }
 

--- a/src/main/java/graphql/validation/rules/NoUndefinedVariables.java
+++ b/src/main/java/graphql/validation/rules/NoUndefinedVariables.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public class NoUndefinedVariables extends AbstractRule {
 
-    private Set<String> variableNames = new LinkedHashSet<>();
+    private Set<String> variableNames = new LinkedHashSet<String>();
 
     public NoUndefinedVariables(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);

--- a/src/main/java/graphql/validation/rules/NoUnusedFragments.java
+++ b/src/main/java/graphql/validation/rules/NoUnusedFragments.java
@@ -15,11 +15,11 @@ import java.util.Map;
 public class NoUnusedFragments extends AbstractRule {
 
 
-    private final List<FragmentDefinition> allDeclaredFragments = new ArrayList<>();
+    private final List<FragmentDefinition> allDeclaredFragments = new ArrayList<FragmentDefinition>();
 
-    private List<String> usedFragments = new ArrayList<>();
-    private Map<String, List<String>> spreadsInDefinition = new LinkedHashMap<>();
-    private final List<List<String>> fragmentsUsedDirectlyInOperation = new ArrayList<>();
+    private List<String> usedFragments = new ArrayList<String>();
+    private Map<String, List<String>> spreadsInDefinition = new LinkedHashMap<String, List<String>>();
+    private final List<List<String>> fragmentsUsedDirectlyInOperation = new ArrayList<List<String>>();
 
     public NoUnusedFragments(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
@@ -27,7 +27,7 @@ public class NoUnusedFragments extends AbstractRule {
 
     @Override
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
-        usedFragments = new ArrayList<>();
+        usedFragments = new ArrayList<String>();
         fragmentsUsedDirectlyInOperation.add(usedFragments);
     }
 
@@ -40,14 +40,14 @@ public class NoUnusedFragments extends AbstractRule {
     @Override
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
         allDeclaredFragments.add(fragmentDefinition);
-        usedFragments = new ArrayList<>();
+        usedFragments = new ArrayList<String>();
         spreadsInDefinition.put(fragmentDefinition.getName(), usedFragments);
     }
 
     @Override
     public void documentFinished(Document document) {
 
-        List<String> allUsedFragments = new ArrayList<>();
+        List<String> allUsedFragments = new ArrayList<String>();
         for (List<String> fragmentsInOneOperation : fragmentsUsedDirectlyInOperation) {
             for (String fragment : fragmentsInOneOperation) {
                 collectUsedFragmentsInDefinition(allUsedFragments, fragment);

--- a/src/main/java/graphql/validation/rules/NoUnusedVariables.java
+++ b/src/main/java/graphql/validation/rules/NoUnusedVariables.java
@@ -13,8 +13,8 @@ import java.util.Set;
 
 public class NoUnusedVariables extends AbstractRule {
 
-    private List<VariableDefinition> variableDefinitions = new ArrayList<>();
-    private Set<String> usedVariables = new LinkedHashSet<>();
+    private List<VariableDefinition> variableDefinitions = new ArrayList<VariableDefinition>();
+    private Set<String> usedVariables = new LinkedHashSet<String>();
 
     public NoUnusedVariables(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -18,7 +18,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
     ErrorFactory errorFactory = new ErrorFactory();
 
 
-    private List<FieldPair> alreadyChecked = new ArrayList<>();
+    private List<FieldPair> alreadyChecked = new ArrayList<FieldPair>();
 
     public OverlappingFieldsCanBeMerged(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
@@ -26,8 +26,8 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
 
     @Override
     public void leaveSelectionSet(SelectionSet selectionSet) {
-        Map<String, List<FieldAndType>> fieldMap = new LinkedHashMap<>();
-        Set<String> visitedFragmentSpreads = new LinkedHashSet<>();
+        Map<String, List<FieldAndType>> fieldMap = new LinkedHashMap<String, List<FieldAndType>>();
+        Set<String> visitedFragmentSpreads = new LinkedHashSet<String>();
         collectFields(fieldMap, selectionSet, getValidationContext().getOutputType(), visitedFragmentSpreads);
         List<Conflict> conflicts = findConflicts(fieldMap);
         for (Conflict conflict : conflicts) {
@@ -38,7 +38,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
 
 
     private List<Conflict> findConflicts(Map<String, List<FieldAndType>> fieldMap) {
-        List<Conflict> result = new ArrayList<>();
+        List<Conflict> result = new ArrayList<Conflict>();
         for (String name : fieldMap.keySet()) {
             List<FieldAndType> fieldAndTypes = fieldMap.get(name);
             for (int i = 0; i < fieldAndTypes.size(); i++) {
@@ -120,14 +120,14 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
         SelectionSet selectionSet1 = field1.getSelectionSet();
         SelectionSet selectionSet2 = field2.getSelectionSet();
         if (selectionSet1 != null && selectionSet2 != null) {
-            Set<String> visitedFragmentSpreads = new LinkedHashSet<>();
-            Map<String, List<FieldAndType>> subFieldMap = new LinkedHashMap<>();
+            Set<String> visitedFragmentSpreads = new LinkedHashSet<String>();
+            Map<String, List<FieldAndType>> subFieldMap = new LinkedHashMap<String, List<FieldAndType>>();
             collectFields(subFieldMap, selectionSet1, type1, visitedFragmentSpreads);
             collectFields(subFieldMap, selectionSet2, type2, visitedFragmentSpreads);
             List<Conflict> subConflicts = findConflicts(subFieldMap);
             if (subConflicts.size() > 0) {
                 String reason = String.format("%s: %s", responseName, joinReasons(subConflicts));
-                List<Field> fields = new ArrayList<>();
+                List<Field> fields = new ArrayList<Field>();
                 fields.add(field1);
                 fields.add(field2);
                 fields.addAll(collectFields(subConflicts));
@@ -140,7 +140,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
     }
 
     private List<Field> collectFields(List<Conflict> conflicts) {
-        List<Field> result = new ArrayList<>();
+        List<Field> result = new ArrayList<Field>();
         for (Conflict conflict : conflicts) {
             result.addAll(conflict.fields);
         }
@@ -273,7 +273,7 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
     private static class Conflict {
         String responseName;
         String reason;
-        List<Field> fields = new ArrayList<>();
+        List<Field> fields = new ArrayList<Field>();
 
         public Conflict(String responseName, String reason, Field field1, Field field2) {
             this.responseName = responseName;

--- a/src/main/java/graphql/validation/rules/ProvidedNonNullArguments.java
+++ b/src/main/java/graphql/validation/rules/ProvidedNonNullArguments.java
@@ -38,7 +38,7 @@ public class ProvidedNonNullArguments extends AbstractRule {
     }
 
     private Map<String, Argument> argumentMap(List<Argument> arguments) {
-        Map<String, Argument> result = new LinkedHashMap<>();
+        Map<String, Argument> result = new LinkedHashMap<String, Argument>();
         for (Argument argument : arguments) {
             result.put(argument.getName(), argument);
         }

--- a/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
+++ b/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
@@ -25,7 +25,7 @@ public class VariableTypesMatchRule extends AbstractRule {
 
     @Override
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
-        variableDefinitionMap = new LinkedHashMap<>();
+        variableDefinitionMap = new LinkedHashMap<String, VariableDefinition>();
     }
 
     @Override

--- a/src/test/groovy/graphql/GarfieldSchema.java
+++ b/src/test/groovy/graphql/GarfieldSchema.java
@@ -80,7 +80,7 @@ public class GarfieldSchema {
         }
 
         public List<Object> getPets() {
-            List<Object> pets = new ArrayList<>();
+            List<Object> pets = new ArrayList<Object>();
             pets.addAll(cats);
             pets.addAll(dogs);
             return pets;

--- a/src/test/groovy/graphql/execution/batched/FunWithStringsSchemaFactory.java
+++ b/src/test/groovy/graphql/execution/batched/FunWithStringsSchemaFactory.java
@@ -39,7 +39,7 @@ public class FunWithStringsSchemaFactory {
             @SuppressWarnings("unchecked")
             public Object get(DataFetchingEnvironment environment) {
                 increment(callCounts, CallType.VALUE);
-                List<String> retVal = new ArrayList<>();
+                List<String> retVal = new ArrayList<String>();
                 for (String s: (List<String>) environment.getSource()) {
                     retVal.add("null".equals(s) ? null : s);
                 }
@@ -53,7 +53,7 @@ public class FunWithStringsSchemaFactory {
             @SuppressWarnings("unchecked")
             public Object get(DataFetchingEnvironment environment) {
                 increment(callCounts, CallType.APPEND);
-                List<String> retVal = new ArrayList<>();
+                List<String> retVal = new ArrayList<String>();
                 for (String s: (List<String>) environment.getSource()) {
                     retVal.add(s + environment.getArgument("text"));
                 }
@@ -68,11 +68,11 @@ public class FunWithStringsSchemaFactory {
             public Object get(DataFetchingEnvironment environment) {
                 increment(callCounts, CallType.WORDS_AND_LETTERS);
                 List<String> sources = (List<String>) environment.getSource();
-                List<List<List<String>>> retVal = new ArrayList<>();
+                List<List<List<String>>> retVal = new ArrayList<List<List<String>>>();
                 for (String source : sources) {
-                    List<List<String>> sentence = new ArrayList<>();
+                    List<List<String>> sentence = new ArrayList<List<String>>();
                     for (String word : source.split(" ")) {
-                        List<String> letters = new ArrayList<>();
+                        List<String> letters = new ArrayList<String>();
                         for (char c : word.toCharArray()) {
                             letters.add(Character.toString(c));
                         }
@@ -92,7 +92,7 @@ public class FunWithStringsSchemaFactory {
                 increment(callCounts, CallType.SPLIT);
                 String regex = environment.getArgument("regex");
                 List<String> sources = (List<String>) environment.getSource();
-                List<List<String>> retVal = new ArrayList<>();
+                List<List<String>> retVal = new ArrayList<List<String>>();
                 if (regex == null) {
                     for (String source: sources) {
                         retVal.add(null);
@@ -100,7 +100,7 @@ public class FunWithStringsSchemaFactory {
                     return retVal;
                 }
                 for (String source: sources) {
-                    List<String> retItem = new ArrayList<>();
+                    List<String> retItem = new ArrayList<String>();
                     for (String str: source.split(regex)) {
                         if (str.isEmpty()) {
                             retItem.add(null);
@@ -121,9 +121,9 @@ public class FunWithStringsSchemaFactory {
             public Object get(DataFetchingEnvironment environment) {
                 increment(callCounts, CallType.SHATTER);
                 List<String> sources = (List<String>) environment.getSource();
-                List<List<String>> retVal = new ArrayList<>();
+                List<List<String>> retVal = new ArrayList<List<String>>();
                 for (String source: sources) {
-                    List<String> retItem = new ArrayList<>();
+                    List<String> retItem = new ArrayList<String>();
                     for (char c: source.toCharArray()) {
                         retItem.add(Character.toString(c));
                     }
@@ -152,7 +152,7 @@ public class FunWithStringsSchemaFactory {
             if(source.isEmpty()) {
                 return null; // trigger error
             }
-            List<String> retVal = new ArrayList<>();
+            List<String> retVal = new ArrayList<String>();
             for (char c: source.toCharArray()) {
                 retVal.add(Character.toString(c));
             }
@@ -164,9 +164,9 @@ public class FunWithStringsSchemaFactory {
         @Override
         public Object get(DataFetchingEnvironment e) {
             String source = (String) e.getSource();
-            List<List<String>> retVal = new ArrayList<>();
+            List<List<String>> retVal = new ArrayList<List<String>>();
             for (String word: source.split(" ")) {
-                List<String> retItem = new ArrayList<>();
+                List<String> retItem = new ArrayList<String>();
                 for (char c: word.toCharArray()) {
                     retItem.add(Character.toString(c));
                 }
@@ -184,7 +184,7 @@ public class FunWithStringsSchemaFactory {
                 return null;
             }
             String source = (String) e.getSource();
-            List<String> retVal = new ArrayList<>();
+            List<String> retVal = new ArrayList<String>();
             for (String str: source.split(regex)) {
                 if (str.isEmpty()) {
                     retVal.add(null);


### PR DESCRIPTION
Properly created version of https://github.com/andimarek/graphql-java/pull/81 (this PR uses the right source branch).

We’d like to target using your graphql-java library on some legacy systems that run JDK 1.6 (not for great technical reasons, but this is how certain company / government bureaucracies work). I was wondering if you’d be willing to accept a patch which would change your “sourceCompatibility” to 1.6?

The changes in the patch entail:

(1) Changing all usage of the diamond operator (<>) to use the fully-specified type, e.g.:

                Map<String, GraphQLType> typesByName = new LinkedHashMap<>();

becomes:

                Map<String, GraphQLType> typesByName = new LinkedHashMap<String, GraphQLType>();

(2) Unrolling multi-catch statements (e.g., “catch (IllegalAccessException | InvocationTargetException e)”). This only happens in a couple places.

In other words, I think the changes here are mostly cosmetic, but it would greatly increase our ability to roll your awesome library out to more places!

Thanks for your consideration.
