### PR TITLE
Adding autogenerated javadoc for versions v1.0, v1.2, v1.3

### DIFF
--- a/src/main/java/graphql/Assert.java
+++ b/src/main/java/graphql/Assert.java
@@ -1,9 +1,21 @@
 package graphql;
 
 
+/**
+ * <p>Assert class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Assert {
 
 
+    /**
+     * <p>assertNotNull.</p>
+     *
+     * @param object a {@link java.lang.Object} object.
+     * @param errorMessage a {@link java.lang.String} object.
+     */
     public static void assertNotNull(Object object, String errorMessage) {
         if (object != null) return;
         throw new AssertException(errorMessage);

--- a/src/main/java/graphql/AssertException.java
+++ b/src/main/java/graphql/AssertException.java
@@ -1,8 +1,19 @@
 package graphql;
 
 
+/**
+ * <p>AssertException class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class AssertException extends GraphQLException {
 
+    /**
+     * <p>Constructor for AssertException.</p>
+     *
+     * @param message a {@link java.lang.String} object.
+     */
     public AssertException(String message) {
         super(message);
     }

--- a/src/main/java/graphql/Directives.java
+++ b/src/main/java/graphql/Directives.java
@@ -7,8 +7,15 @@ import graphql.schema.GraphQLNonNull;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.schema.GraphQLArgument.newArgument;
 
+/**
+ * <p>Directives class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Directives {
 
+    /** Constant <code>IncludeDirective</code> */
     public static GraphQLDirective IncludeDirective = GraphQLDirective.newDirective()
             .name("include")
             .description("Directs the executor to include this field or fragment only when the `if` argument is true")
@@ -22,6 +29,7 @@ public class Directives {
             .onField(true)
             .build();
 
+    /** Constant <code>SkipDirective</code> */
     public static GraphQLDirective SkipDirective = GraphQLDirective.newDirective()
             .name("skip")
             .description("Directs the executor to skip this field or fragment when the `if`'argument is true.")

--- a/src/main/java/graphql/ErrorType.java
+++ b/src/main/java/graphql/ErrorType.java
@@ -1,6 +1,12 @@
 package graphql;
 
 
+/**
+ * <p>ErrorType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public enum ErrorType {
 
     InvalidSyntax,

--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -5,34 +5,54 @@ import graphql.language.SourceLocation;
 
 import java.util.List;
 
+/**
+ * <p>ExceptionWhileDataFetching class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class ExceptionWhileDataFetching implements GraphQLError {
 
     private final Exception exception;
 
+    /**
+     * <p>Constructor for ExceptionWhileDataFetching.</p>
+     *
+     * @param exception a {@link java.lang.Exception} object.
+     */
     public ExceptionWhileDataFetching(Exception exception) {
         this.exception = exception;
     }
 
+    /**
+     * <p>Getter for the field <code>exception</code>.</p>
+     *
+     * @return a {@link java.lang.Exception} object.
+     */
     public Exception getException() {
         return exception;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String getMessage() {
         return "Exception while fetching data: " + exception.toString();
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<SourceLocation> getLocations() {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public ErrorType getErrorType() {
         return ErrorType.DataFetchingException;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "ExceptionWhileDataFetching{" +

--- a/src/main/java/graphql/ExecutionResult.java
+++ b/src/main/java/graphql/ExecutionResult.java
@@ -4,9 +4,25 @@ package graphql;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>ExecutionResult interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public interface ExecutionResult {
 
+    /**
+     * <p>getData.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     Object getData();
 
+    /**
+     * <p>getErrors.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     List<GraphQLError> getErrors();
 }

--- a/src/main/java/graphql/ExecutionResultImpl.java
+++ b/src/main/java/graphql/ExecutionResultImpl.java
@@ -5,15 +5,32 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>ExecutionResultImpl class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class ExecutionResultImpl implements ExecutionResult {
 
     private final List<GraphQLError> errors = new ArrayList<>();
     private Object data;
 
+    /**
+     * <p>Constructor for ExecutionResultImpl.</p>
+     *
+     * @param errors a {@link java.util.List} object.
+     */
     public ExecutionResultImpl(List<? extends GraphQLError> errors) {
         this.errors.addAll(errors);
     }
 
+    /**
+     * <p>Constructor for ExecutionResultImpl.</p>
+     *
+     * @param data a {@link java.lang.Object} object.
+     * @param errors a {@link java.util.List} object.
+     */
     public ExecutionResultImpl(Object data, List<? extends GraphQLError> errors) {
         this.data = data;
 
@@ -22,19 +39,31 @@ public class ExecutionResultImpl implements ExecutionResult {
         }
     }
 
+    /**
+     * <p>addErrors.</p>
+     *
+     * @param errors a {@link java.util.List} object.
+     */
     public void addErrors(List<? extends GraphQLError> errors) {
         this.errors.addAll(errors);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Object getData() {
         return data;
     }
 
+    /**
+     * <p>Setter for the field <code>data</code>.</p>
+     *
+     * @param result a {@link java.lang.Object} object.
+     */
     public void setData(Object result) {
         this.data = result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<GraphQLError> getErrors() {
         return new ArrayList<>(errors);

--- a/src/main/java/graphql/GraphQL.java
+++ b/src/main/java/graphql/GraphQL.java
@@ -21,6 +21,12 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQL class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQL {
 
 
@@ -29,32 +35,81 @@ public class GraphQL {
 
     private static final Logger log = LoggerFactory.getLogger(GraphQL.class);
 
+    /**
+     * <p>Constructor for GraphQL.</p>
+     *
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     */
     public GraphQL(GraphQLSchema graphQLSchema) {
         this(graphQLSchema, null);
     }
 
 
+    /**
+     * <p>Constructor for GraphQL.</p>
+     *
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     * @param executionStrategy a {@link graphql.execution.ExecutionStrategy} object.
+     */
     public GraphQL(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy) {
         this.graphQLSchema = graphQLSchema;
         this.executionStrategy = executionStrategy;
     }
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param requestString a {@link java.lang.String} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public ExecutionResult execute(String requestString) {
         return execute(requestString, null);
     }
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param requestString a {@link java.lang.String} object.
+     * @param context a {@link java.lang.Object} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public ExecutionResult execute(String requestString, Object context) {
         return execute(requestString, context, Collections.<String, Object>emptyMap());
     }
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param requestString a {@link java.lang.String} object.
+     * @param operationName a {@link java.lang.String} object.
+     * @param context a {@link java.lang.Object} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public ExecutionResult execute(String requestString, String operationName, Object context) {
         return execute(requestString, operationName, context, Collections.<String, Object>emptyMap());
     }
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param requestString a {@link java.lang.String} object.
+     * @param context a {@link java.lang.Object} object.
+     * @param arguments a {@link java.util.Map} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public ExecutionResult execute(String requestString, Object context, Map<String, Object> arguments) {
         return execute(requestString, null, context, arguments);
     }
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param requestString a {@link java.lang.String} object.
+     * @param operationName a {@link java.lang.String} object.
+     * @param context a {@link java.lang.Object} object.
+     * @param arguments a {@link java.util.Map} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public ExecutionResult execute(String requestString, String operationName, Object context, Map<String, Object> arguments) {
         assertNotNull(arguments, "arguments can't be null");
         log.info("Executing request. operation name: {}. Request: {} ", operationName, requestString);

--- a/src/main/java/graphql/GraphQLError.java
+++ b/src/main/java/graphql/GraphQLError.java
@@ -5,12 +5,33 @@ import graphql.language.SourceLocation;
 
 import java.util.List;
 
+/**
+ * <p>GraphQLError interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public interface GraphQLError {
 
+    /**
+     * <p>getMessage.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     String getMessage();
 
+    /**
+     * <p>getLocations.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     List<SourceLocation> getLocations();
 
+    /**
+     * <p>getErrorType.</p>
+     *
+     * @return a {@link graphql.ErrorType} object.
+     */
     ErrorType getErrorType();
 
 }

--- a/src/main/java/graphql/GraphQLException.java
+++ b/src/main/java/graphql/GraphQLException.java
@@ -1,19 +1,44 @@
 package graphql;
 
 
+/**
+ * <p>GraphQLException class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLException extends RuntimeException{
 
+    /**
+     * <p>Constructor for GraphQLException.</p>
+     */
     public GraphQLException() {
     }
 
+    /**
+     * <p>Constructor for GraphQLException.</p>
+     *
+     * @param message a {@link java.lang.String} object.
+     */
     public GraphQLException(String message) {
         super(message);
     }
 
+    /**
+     * <p>Constructor for GraphQLException.</p>
+     *
+     * @param message a {@link java.lang.String} object.
+     * @param cause a {@link java.lang.Throwable} object.
+     */
     public GraphQLException(String message, Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * <p>Constructor for GraphQLException.</p>
+     *
+     * @param cause a {@link java.lang.Throwable} object.
+     */
     public GraphQLException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/graphql/InvalidSyntaxError.java
+++ b/src/main/java/graphql/InvalidSyntaxError.java
@@ -6,15 +6,31 @@ import graphql.language.SourceLocation;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>InvalidSyntaxError class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class InvalidSyntaxError implements GraphQLError {
 
     private final List<SourceLocation> sourceLocations = new ArrayList<>();
 
+    /**
+     * <p>Constructor for InvalidSyntaxError.</p>
+     *
+     * @param sourceLocation a {@link graphql.language.SourceLocation} object.
+     */
     public InvalidSyntaxError(SourceLocation sourceLocation) {
         if (sourceLocation != null)
             this.sourceLocations.add(sourceLocation);
     }
 
+    /**
+     * <p>Constructor for InvalidSyntaxError.</p>
+     *
+     * @param sourceLocations a {@link java.util.List} object.
+     */
     public InvalidSyntaxError(List<SourceLocation> sourceLocations) {
         if (sourceLocations != null) {
             this.sourceLocations.addAll(sourceLocations);
@@ -22,21 +38,25 @@ public class InvalidSyntaxError implements GraphQLError {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String getMessage() {
         return "Invalid Syntax";
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<SourceLocation> getLocations() {
         return sourceLocations;
     }
 
+    /** {@inheritDoc} */
     @Override
     public ErrorType getErrorType() {
         return ErrorType.InvalidSyntax;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "InvalidSyntaxError{" +

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -8,9 +8,16 @@ import graphql.language.StringValue;
 import graphql.schema.Coercing;
 import graphql.schema.GraphQLScalarType;
 
+/**
+ * <p>Scalars class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Scalars {
 
 
+    /** Constant <code>GraphQLInt</code> */
     public static GraphQLScalarType GraphQLInt = new GraphQLScalarType("Int", "Built-in Int", new Coercing() {
         @Override
         public Object serialize(Object input) {
@@ -36,6 +43,7 @@ public class Scalars {
     });
 
 
+    /** Constant <code>GraphQLLong</code> */
     public static GraphQLScalarType GraphQLLong = new GraphQLScalarType("Long", "Long type", new Coercing() {
         @Override
         public Object serialize(Object input) {
@@ -66,6 +74,7 @@ public class Scalars {
         }
     });
 
+    /** Constant <code>GraphQLFloat</code> */
     public static GraphQLScalarType GraphQLFloat = new GraphQLScalarType("Float", "Built-in Float", new Coercing() {
         @Override
         public Double serialize(Object input) {
@@ -93,6 +102,7 @@ public class Scalars {
         }
     });
 
+    /** Constant <code>GraphQLString</code> */
     public static GraphQLScalarType GraphQLString = new GraphQLScalarType("String", "Built-in String", new Coercing() {
         @Override
         public Object serialize(Object input) {
@@ -112,6 +122,7 @@ public class Scalars {
     });
 
 
+    /** Constant <code>GraphQLBoolean</code> */
     public static GraphQLScalarType GraphQLBoolean = new GraphQLScalarType("Boolean", "Built-in Boolean", new Coercing() {
         @Override
         public Object serialize(Object input) {
@@ -139,6 +150,7 @@ public class Scalars {
     });
 
 
+    /** Constant <code>GraphQLID</code> */
     public static GraphQLScalarType GraphQLID = new GraphQLScalarType("ID", "Built-in ID", new Coercing() {
         @Override
         public Object serialize(Object input) {

--- a/src/main/java/graphql/ShouldNotHappenException.java
+++ b/src/main/java/graphql/ShouldNotHappenException.java
@@ -1,8 +1,17 @@
 package graphql;
 
 
+/**
+ * <p>ShouldNotHappenException class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ShouldNotHappenException extends GraphQLException {
 
+    /**
+     * <p>Constructor for ShouldNotHappenException.</p>
+     */
     public ShouldNotHappenException() {
         super("This should not happen ..it's probably a bug");
     }

--- a/src/main/java/graphql/execution/ConditionalNodes.java
+++ b/src/main/java/graphql/execution/ConditionalNodes.java
@@ -9,14 +9,30 @@ import static graphql.Directives.IncludeDirective;
 import static graphql.Directives.SkipDirective;
 
 
+/**
+ * <p>ConditionalNodes class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ConditionalNodes {
 
     ValuesResolver valuesResolver;
 
+    /**
+     * <p>Constructor for ConditionalNodes.</p>
+     */
     public ConditionalNodes() {
         valuesResolver = new ValuesResolver();
     }
 
+    /**
+     * <p>shouldInclude.</p>
+     *
+     * @param executionContext a {@link graphql.execution.ExecutionContext} object.
+     * @param directives a {@link java.util.List} object.
+     * @return a boolean.
+     */
     public boolean shouldInclude(ExecutionContext executionContext, List<Directive> directives) {
 
         Directive skipDirective = findDirective(directives, SkipDirective.getName());

--- a/src/main/java/graphql/execution/Execution.java
+++ b/src/main/java/graphql/execution/Execution.java
@@ -14,11 +14,22 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>Execution class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Execution {
 
     private FieldCollector fieldCollector = new FieldCollector();
     private ExecutionStrategy strategy;
 
+    /**
+     * <p>Constructor for Execution.</p>
+     *
+     * @param strategy a {@link graphql.execution.ExecutionStrategy} object.
+     */
     public Execution(ExecutionStrategy strategy) {
         this.strategy = strategy;
 
@@ -27,6 +38,16 @@ public class Execution {
         }
     }
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     * @param root a {@link java.lang.Object} object.
+     * @param document a {@link graphql.language.Document} object.
+     * @param operationName a {@link java.lang.String} object.
+     * @param args a {@link java.util.Map} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public ExecutionResult execute(GraphQLSchema graphQLSchema, Object root, Document document, String operationName, Map<String, Object> args) {
         ExecutionContextBuilder executionContextBuilder = new ExecutionContextBuilder(new ValuesResolver());
         ExecutionContext executionContext = executionContextBuilder.build(graphQLSchema, strategy, root, document, operationName, args);

--- a/src/main/java/graphql/execution/ExecutionContext.java
+++ b/src/main/java/graphql/execution/ExecutionContext.java
@@ -11,6 +11,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>ExecutionContext class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ExecutionContext {
 
     private GraphQLSchema graphQLSchema;
@@ -21,62 +27,138 @@ public class ExecutionContext {
     private Object root;
     private List<GraphQLError> errors = new ArrayList<>();
 
+    /**
+     * <p>Getter for the field <code>graphQLSchema</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLSchema} object.
+     */
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;
     }
 
+    /**
+     * <p>Setter for the field <code>graphQLSchema</code>.</p>
+     *
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     */
     public void setGraphQLSchema(GraphQLSchema graphQLSchema) {
         this.graphQLSchema = graphQLSchema;
     }
 
+    /**
+     * <p>Getter for the field <code>fragmentsByName</code>.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, FragmentDefinition> getFragmentsByName() {
         return fragmentsByName;
     }
 
+    /**
+     * <p>Setter for the field <code>fragmentsByName</code>.</p>
+     *
+     * @param fragmentsByName a {@link java.util.Map} object.
+     */
     public void setFragmentsByName(Map<String, FragmentDefinition> fragmentsByName) {
         this.fragmentsByName = fragmentsByName;
     }
 
+    /**
+     * <p>Getter for the field <code>operationDefinition</code>.</p>
+     *
+     * @return a {@link graphql.language.OperationDefinition} object.
+     */
     public OperationDefinition getOperationDefinition() {
         return operationDefinition;
     }
 
+    /**
+     * <p>Setter for the field <code>operationDefinition</code>.</p>
+     *
+     * @param operationDefinition a {@link graphql.language.OperationDefinition} object.
+     */
     public void setOperationDefinition(OperationDefinition operationDefinition) {
         this.operationDefinition = operationDefinition;
     }
 
+    /**
+     * <p>Getter for the field <code>variables</code>.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, Object> getVariables() {
         return variables;
     }
 
+    /**
+     * <p>Setter for the field <code>variables</code>.</p>
+     *
+     * @param variables a {@link java.util.Map} object.
+     */
     public void setVariables(Map<String, Object> variables) {
         this.variables = variables;
     }
 
+    /**
+     * <p>Getter for the field <code>root</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getRoot() {
         return root;
     }
 
+    /**
+     * <p>Setter for the field <code>root</code>.</p>
+     *
+     * @param root a {@link java.lang.Object} object.
+     */
     public void setRoot(Object root) {
         this.root = root;
     }
 
+    /**
+     * <p>getFragment.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.language.FragmentDefinition} object.
+     */
     public FragmentDefinition getFragment(String name) {
         return fragmentsByName.get(name);
     }
 
+    /**
+     * <p>addError.</p>
+     *
+     * @param error a {@link graphql.GraphQLError} object.
+     */
     public void addError(GraphQLError error) {
         this.errors.add(error);
     }
 
+    /**
+     * <p>Getter for the field <code>errors</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLError> getErrors(){
         return errors;
     }
 
+    /**
+     * <p>Getter for the field <code>executionStrategy</code>.</p>
+     *
+     * @return a {@link graphql.execution.ExecutionStrategy} object.
+     */
     public ExecutionStrategy getExecutionStrategy() {
         return executionStrategy;
     }
 
+    /**
+     * <p>Setter for the field <code>executionStrategy</code>.</p>
+     *
+     * @param executionStrategy a {@link graphql.execution.ExecutionStrategy} object.
+     */
     public void setExecutionStrategy(ExecutionStrategy executionStrategy) {
         this.executionStrategy = executionStrategy;
     }

--- a/src/main/java/graphql/execution/ExecutionContextBuilder.java
+++ b/src/main/java/graphql/execution/ExecutionContextBuilder.java
@@ -10,14 +10,36 @@ import graphql.schema.GraphQLSchema;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>ExecutionContextBuilder class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ExecutionContextBuilder {
 
     private ValuesResolver valuesResolver;
 
+    /**
+     * <p>Constructor for ExecutionContextBuilder.</p>
+     *
+     * @param valuesResolver a {@link graphql.execution.ValuesResolver} object.
+     */
     public ExecutionContextBuilder(ValuesResolver valuesResolver) {
         this.valuesResolver = valuesResolver;
     }
 
+    /**
+     * <p>build.</p>
+     *
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     * @param executionStrategy a {@link graphql.execution.ExecutionStrategy} object.
+     * @param root a {@link java.lang.Object} object.
+     * @param document a {@link graphql.language.Document} object.
+     * @param operationName a {@link java.lang.String} object.
+     * @param args a {@link java.util.Map} object.
+     * @return a {@link graphql.execution.ExecutionContext} object.
+     */
     public ExecutionContext build(GraphQLSchema graphQLSchema, ExecutionStrategy executionStrategy, Object root, Document document, String operationName, Map<String, Object> args) {
         Map<String, FragmentDefinition> fragmentsByName = new LinkedHashMap<>();
         Map<String, OperationDefinition> operationsByName = new LinkedHashMap<>();

--- a/src/main/java/graphql/execution/ExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutionStrategy.java
@@ -13,14 +13,38 @@ import java.util.*;
 
 import static graphql.introspection.Introspection.*;
 
+/**
+ * <p>Abstract ExecutionStrategy class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public abstract class ExecutionStrategy {
     private static final Logger log = LoggerFactory.getLogger(ExecutionStrategy.class);
 
     protected ValuesResolver valuesResolver = new ValuesResolver();
     protected FieldCollector fieldCollector = new FieldCollector();
 
+    /**
+     * <p>execute.</p>
+     *
+     * @param executionContext a {@link graphql.execution.ExecutionContext} object.
+     * @param parentType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param source a {@link java.lang.Object} object.
+     * @param fields a {@link java.util.Map} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     public abstract ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields);
 
+    /**
+     * <p>resolveField.</p>
+     *
+     * @param executionContext a {@link graphql.execution.ExecutionContext} object.
+     * @param parentType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param source a {@link java.lang.Object} object.
+     * @param fields a {@link java.util.List} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     protected ExecutionResult resolveField(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, List<Field> fields) {
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, fields.get(0));
         if (fieldDef == null) return null;
@@ -47,6 +71,15 @@ public abstract class ExecutionStrategy {
         return completeValue(executionContext, fieldDef.getType(), fields, resolvedValue);
     }
 
+    /**
+     * <p>completeValue.</p>
+     *
+     * @param executionContext a {@link graphql.execution.ExecutionContext} object.
+     * @param fieldType a {@link graphql.schema.GraphQLType} object.
+     * @param fields a {@link java.util.List} object.
+     * @param result a {@link java.lang.Object} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     protected ExecutionResult completeValue(ExecutionContext executionContext, GraphQLType fieldType, List<Field> fields, Object result) {
         if (fieldType instanceof GraphQLNonNull) {
             GraphQLNonNull graphQLNonNull = (GraphQLNonNull) fieldType;
@@ -97,6 +130,13 @@ public abstract class ExecutionStrategy {
         return completeValueForList(executionContext, fieldType, fields, (List<Object>) result);
     }
 
+    /**
+     * <p>resolveType.</p>
+     *
+     * @param graphQLInterfaceType a {@link graphql.schema.GraphQLInterfaceType} object.
+     * @param value a {@link java.lang.Object} object.
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     protected GraphQLObjectType resolveType(GraphQLInterfaceType graphQLInterfaceType, Object value) {
         GraphQLObjectType result = graphQLInterfaceType.getTypeResolver().getType(value);
         if (result == null) {
@@ -105,6 +145,13 @@ public abstract class ExecutionStrategy {
         return result;
     }
 
+    /**
+     * <p>resolveType.</p>
+     *
+     * @param graphQLUnionType a {@link graphql.schema.GraphQLUnionType} object.
+     * @param value a {@link java.lang.Object} object.
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     protected GraphQLObjectType resolveType(GraphQLUnionType graphQLUnionType, Object value) {
         GraphQLObjectType result = graphQLUnionType.getTypeResolver().getType(value);
         if (result == null) {
@@ -114,14 +161,37 @@ public abstract class ExecutionStrategy {
     }
 
 
+    /**
+     * <p>completeValueForEnum.</p>
+     *
+     * @param enumType a {@link graphql.schema.GraphQLEnumType} object.
+     * @param result a {@link java.lang.Object} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     protected ExecutionResult completeValueForEnum(GraphQLEnumType enumType, Object result) {
         return new ExecutionResultImpl(enumType.getCoercing().serialize(result), null);
     }
 
+    /**
+     * <p>completeValueForScalar.</p>
+     *
+     * @param scalarType a {@link graphql.schema.GraphQLScalarType} object.
+     * @param result a {@link java.lang.Object} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     protected ExecutionResult completeValueForScalar(GraphQLScalarType scalarType, Object result) {
         return new ExecutionResultImpl(scalarType.getCoercing().serialize(result), null);
     }
 
+    /**
+     * <p>completeValueForList.</p>
+     *
+     * @param executionContext a {@link graphql.execution.ExecutionContext} object.
+     * @param fieldType a {@link graphql.schema.GraphQLList} object.
+     * @param fields a {@link java.util.List} object.
+     * @param result a {@link java.util.List} object.
+     * @return a {@link graphql.ExecutionResult} object.
+     */
     protected ExecutionResult completeValueForList(ExecutionContext executionContext, GraphQLList fieldType, List<Field> fields, List<Object> result) {
         List<Object> completedResults = new ArrayList<>();
         for (Object item : result) {
@@ -131,6 +201,14 @@ public abstract class ExecutionStrategy {
         return new ExecutionResultImpl(completedResults, null);
     }
 
+    /**
+     * <p>getFieldDef.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param parentType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param field a {@link graphql.language.Field} object.
+     * @return a {@link graphql.schema.GraphQLFieldDefinition} object.
+     */
     protected GraphQLFieldDefinition getFieldDef(GraphQLSchema schema, GraphQLObjectType parentType, Field field) {
         if (schema.getQueryType() == parentType) {
             if (field.getName().equals(SchemaMetaFieldDef.getName())) {

--- a/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
+++ b/src/main/java/graphql/execution/ExecutorServiceExecutionStrategy.java
@@ -15,9 +15,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 /**
- * ExecutorServiceExecutionStrategy uses an {@link ExecutorService} to parallelize the resolve.
+ * ExecutorServiceExecutionStrategy uses an {@link java.util.concurrent.ExecutorService} to parallelize the resolve.
  * <p>
- * Due to the nature of {@link #execute(ExecutionContext, GraphQLObjectType, Object, Map)} implementation, {@link ExecutorService}
+ * Due to the nature of {@link #execute(ExecutionContext, GraphQLObjectType, Object, Map)} implementation, {@link java.util.concurrent.ExecutorService}
  * MUST have the following 2 characteristics:
  * <ul>
  *     <li>1. The underlying {@link java.util.concurrent.ThreadPoolExecutor} MUST have a reasonable {@code maximumPoolSize}
@@ -27,15 +27,24 @@ import java.util.concurrent.Future;
  * Failure to follow 1. and 2. can result in a very large number of threads created or hanging. (deadlock)
  * <p>
  * See {@code graphql.execution.ExecutorServiceExecutionStrategyTest} for example usage.
+ *
+ * @author Andreas Marek
+ * @version v1.3
  */
 public class ExecutorServiceExecutionStrategy extends ExecutionStrategy {
 
     ExecutorService executorService;
 
+    /**
+     * <p>Constructor for ExecutorServiceExecutionStrategy.</p>
+     *
+     * @param executorService a {@link java.util.concurrent.ExecutorService} object.
+     */
     public ExecutorServiceExecutionStrategy(ExecutorService executorService) {
         this.executorService = executorService;
     }
 
+    /** {@inheritDoc} */
     @Override
     public ExecutionResult execute(final ExecutionContext executionContext, final GraphQLObjectType parentType, final Object source, final Map<String, List<Field>> fields) {
         if (executorService == null) return new SimpleExecutionStrategy().execute(executionContext, parentType, source, fields);

--- a/src/main/java/graphql/execution/FieldCollector.java
+++ b/src/main/java/graphql/execution/FieldCollector.java
@@ -10,17 +10,35 @@ import java.util.Map;
 
 import static graphql.execution.TypeFromAST.getTypeFromAST;
 
+/**
+ * <p>FieldCollector class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class FieldCollector {
 
     private ConditionalNodes conditionalNodes;
 
     private SchemaUtil schemaUtil = new SchemaUtil();
 
+    /**
+     * <p>Constructor for FieldCollector.</p>
+     */
     public FieldCollector() {
         conditionalNodes = new ConditionalNodes();
     }
 
 
+    /**
+     * <p>collectFields.</p>
+     *
+     * @param executionContext a {@link graphql.execution.ExecutionContext} object.
+     * @param type a {@link graphql.schema.GraphQLObjectType} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     * @param visitedFragments a {@link java.util.List} object.
+     * @param fields a {@link java.util.Map} object.
+     */
     public void collectFields(ExecutionContext executionContext, GraphQLObjectType type, SelectionSet selectionSet, List<String> visitedFragments, Map<String, List<Field>> fields) {
 
         for (Selection selection : selectionSet.getSelections()) {

--- a/src/main/java/graphql/execution/SimpleExecutionStrategy.java
+++ b/src/main/java/graphql/execution/SimpleExecutionStrategy.java
@@ -9,7 +9,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>SimpleExecutionStrategy class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class SimpleExecutionStrategy extends ExecutionStrategy {
+    /** {@inheritDoc} */
     @Override
     public ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
         Map<String, Object> results = new LinkedHashMap<>();

--- a/src/main/java/graphql/execution/TypeFromAST.java
+++ b/src/main/java/graphql/execution/TypeFromAST.java
@@ -10,9 +10,22 @@ import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 
+/**
+ * <p>TypeFromAST class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class TypeFromAST {
 
 
+    /**
+     * <p>getTypeFromAST.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param type a {@link graphql.language.Type} object.
+     * @return a {@link graphql.schema.GraphQLType} object.
+     */
     public static GraphQLType getTypeFromAST(GraphQLSchema schema, Type type) {
         if (type instanceof ListType) {
             return new GraphQLList(getTypeFromAST(schema, ((ListType) type).getType()));

--- a/src/main/java/graphql/execution/ValuesResolver.java
+++ b/src/main/java/graphql/execution/ValuesResolver.java
@@ -7,9 +7,23 @@ import graphql.schema.*;
 
 import java.util.*;
 
+/**
+ * <p>ValuesResolver class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ValuesResolver {
 
 
+    /**
+     * <p>getVariableValues.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param variableDefinitions a {@link java.util.List} object.
+     * @param inputs a {@link java.util.Map} object.
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, Object> getVariableValues(GraphQLSchema schema, List<VariableDefinition> variableDefinitions, Map<String, Object> inputs) {
         Map<String, Object> result = new LinkedHashMap<>();
         for (VariableDefinition variableDefinition : variableDefinitions) {
@@ -19,6 +33,14 @@ public class ValuesResolver {
     }
 
 
+    /**
+     * <p>getArgumentValues.</p>
+     *
+     * @param argumentTypes a {@link java.util.List} object.
+     * @param arguments a {@link java.util.List} object.
+     * @param variables a {@link java.util.Map} object.
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, Object> getArgumentValues(List<GraphQLArgument> argumentTypes, List<Argument> arguments, Map<String, Object> variables) {
         Map<String, Object> result = new LinkedHashMap<>();
         Map<String, Argument> argumentMap = argumentMap(arguments);

--- a/src/main/java/graphql/execution/batched/Batched.java
+++ b/src/main/java/graphql/execution/batched/Batched.java
@@ -10,51 +10,52 @@ import java.lang.annotation.Target;
 /**
  * <p>
  * When placed on {@link graphql.schema.DataFetcher#get(DataFetchingEnvironment)}, indicates that this DataFetcher is batched.
- * This annotation must be used in conjunction with {@link BatchedExecutionStrategy}. Batching is valuable in many
+ * This annotation must be used in conjunction with {@link graphql.execution.batched.BatchedExecutionStrategy}. Batching is valuable in many
  * situations, such as when a {@link graphql.schema.DataFetcher} must make a network or file system request.
  * </p>
  *
  * <p>
- * When a {@link graphql.schema.DataFetcher} is batched, the {@link DataFetchingEnvironment#getSource()} method is
+ * When a {@link graphql.schema.DataFetcher} is batched, the {@link graphql.schema.DataFetchingEnvironment#getSource()} method is
  * guaranteed to return a {@link java.util.List}.  The {@link graphql.schema.DataFetcher#get(DataFetchingEnvironment)}
  * method MUST return a parallel {@link java.util.List} which is equivalent to running a {@link graphql.schema.DataFetcher}
  * over each input element individually.
  * </p>
  *
  * <p>
- *     Using the {@link Batched} annotation is equivalent to implementing {@link BatchedDataFetcher} instead of {@link graphql.schema.DataFetcher}.
- *     It is preferred to use the {@link Batched} annotation.
+ *     Using the {@link graphql.execution.batched.Batched} annotation is equivalent to implementing {@link graphql.execution.batched.BatchedDataFetcher} instead of {@link graphql.schema.DataFetcher}.
+ *     It is preferred to use the {@link graphql.execution.batched.Batched} annotation.
  * </p>
  *
  * For example, the following two {@link graphql.schema.DataFetcher} objects are interchangeable if used with a
- * {@link BatchedExecutionStrategy}.
- <pre>
-  <code>
- new DataFetcher() {
-     {@literal @}Override
-     {@literal @}Batched
-      public Object get(DataFetchingEnvironment environment) {
-         {@code List<String> retVal = new ArrayList<>();}
-         {@code for (String s: (List<String>) environment.getSource())} {
-            retVal.add(s + environment.getArgument("text"));
-        }
-       return retVal;
-      }
-    }
- </code>
- </pre>
+ * {@link graphql.execution.batched.BatchedExecutionStrategy}.
+ * <pre>
+ *  <code>
+ * new DataFetcher() {
+ *     {@literal @}Override
+ *     {@literal @}Batched
+ *      public Object get(DataFetchingEnvironment environment) {
+ *         {@code List<String> retVal = new ArrayList<>();}
+ *         {@code for (String s: (List<String>) environment.getSource())} {
+ *            retVal.add(s + environment.getArgument("text"));
+ *        }
+ *       return retVal;
+ *      }
+ *    }
+ * </code>
+ * </pre>
  *
  * <pre>
  * <code>
- new DataFetcher() {
-     {@literal @}Override
-      public Object get(DataFetchingEnvironment e) {
-          return ((String)e.getSource()) + e.getArgument("text");
-      }
- }
-</code>
+ * new DataFetcher() {
+ *     {@literal @}Override
+ *      public Object get(DataFetchingEnvironment e) {
+ *          return ((String)e.getSource()) + e.getArgument("text");
+ *      }
+ * }
+ *</code>
  * </pre>
  *
+ * @author Andreas Marek
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/graphql/execution/batched/BatchedDataFetcher.java
+++ b/src/main/java/graphql/execution/batched/BatchedDataFetcher.java
@@ -3,7 +3,9 @@ package graphql.execution.batched;
 import graphql.schema.DataFetcher;
 
 /**
- * See {@link Batched}.
+ * See {@link graphql.execution.batched.Batched}.
+ *
+ * @author Andreas Marek
  */
 public interface BatchedDataFetcher extends DataFetcher {
     // Marker interface

--- a/src/main/java/graphql/execution/batched/BatchedDataFetcherFactory.java
+++ b/src/main/java/graphql/execution/batched/BatchedDataFetcherFactory.java
@@ -13,9 +13,16 @@ import java.lang.reflect.Method;
  * Otherwise we wrap the fetcher in a BatchedDataFetcher that iterates over the sources and invokes the delegate
  * on each source. Note that this forgoes any performance benefits of batching,
  * so regular DataFetchers should normally only be used if they are in-memory.
+ *
+ * @author Andreas Marek
  */
-
 public class BatchedDataFetcherFactory {
+    /**
+     * <p>create.</p>
+     *
+     * @param supplied a {@link graphql.schema.DataFetcher} object.
+     * @return a {@link graphql.execution.batched.BatchedDataFetcher} object.
+     */
     public BatchedDataFetcher create(final DataFetcher supplied) {
         if (supplied instanceof BatchedDataFetcher) {
             return (BatchedDataFetcher) supplied;

--- a/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
+++ b/src/main/java/graphql/execution/batched/BatchedExecutionStrategy.java
@@ -16,14 +16,16 @@ import java.util.*;
 import static java.util.Collections.singletonList;
 
 /**
- * Execution Strategy that minimizes calls to the data fetcher when used in conjunction with {@link DataFetcher}s that have
- * {@link DataFetcher#get(DataFetchingEnvironment)} methods annotated with {@link Batched}. See the javadoc comment on
- * {@link Batched} for a more detailed description of batched data fetchers.
+ * Execution Strategy that minimizes calls to the data fetcher when used in conjunction with {@link graphql.schema.DataFetcher}s that have
+ * {@link graphql.schema.DataFetcher#get(DataFetchingEnvironment)} methods annotated with {@link graphql.execution.batched.Batched}. See the javadoc comment on
+ * {@link graphql.execution.batched.Batched} for a more detailed description of batched data fetchers.
  * <p>
  * The strategy runs a BFS over terms of the query and passes a list of all the relevant sources to the batched data fetcher.
  * </p>
  * Normal DataFetchers can be used, however they will not see benefits of batching as they expect a single source object
  * at a time.
+ *
+ * @author Andreas Marek
  */
 public class BatchedExecutionStrategy extends ExecutionStrategy {
 
@@ -31,6 +33,7 @@ public class BatchedExecutionStrategy extends ExecutionStrategy {
 
     private final BatchedDataFetcherFactory batchingFactory = new BatchedDataFetcherFactory();
 
+    /** {@inheritDoc} */
     @Override
     public ExecutionResult execute(ExecutionContext executionContext, GraphQLObjectType parentType, Object source, Map<String, List<Field>> fields) {
         GraphQLExecutionNodeDatum data = new GraphQLExecutionNodeDatum(new LinkedHashMap<String, Object>(), source);

--- a/src/main/java/graphql/execution/batched/ChildDataCollector.java
+++ b/src/main/java/graphql/execution/batched/ChildDataCollector.java
@@ -7,12 +7,23 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>ChildDataCollector class.</p>
+ *
+ * @author Andreas Marek
+ */
 public class ChildDataCollector {
 
     private final Map<String, List<GraphQLExecutionNodeDatum>> childDataByTypename = new HashMap<>();
     private final Map<String, GraphQLObjectType> childTypesByName = new HashMap<>();
 
 
+    /**
+     * <p>putChildData.</p>
+     *
+     * @param objectType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param datum a {@link graphql.execution.batched.GraphQLExecutionNodeDatum} object.
+     */
     public void putChildData(GraphQLObjectType objectType, GraphQLExecutionNodeDatum datum) {
         childTypesByName.put(objectType.getName(), objectType);
         multimapPut(childDataByTypename, objectType.getName(), datum);
@@ -34,6 +45,11 @@ public class ChildDataCollector {
         return map.get(key);
     }
 
+    /**
+     * <p>getEntries.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Entry> getEntries() {
         List<Entry> entries = new ArrayList<>();
         for (String childTypename: childTypesByName.keySet()) {

--- a/src/main/java/graphql/execution/batched/GraphQLExecutionNode.java
+++ b/src/main/java/graphql/execution/batched/GraphQLExecutionNode.java
@@ -12,6 +12,13 @@ class GraphQLExecutionNode {
     private final Map<String, List<Field>> fields;
     private final List<GraphQLExecutionNodeDatum> data;
 
+    /**
+     * <p>Constructor for GraphQLExecutionNode.</p>
+     *
+     * @param parentType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param fields a {@link java.util.Map} object.
+     * @param data a {@link java.util.List} object.
+     */
     public GraphQLExecutionNode(GraphQLObjectType parentType,
                                 Map<String, List<Field>> fields,
                                 List<GraphQLExecutionNodeDatum> data) {
@@ -20,14 +27,29 @@ class GraphQLExecutionNode {
         this.data = data;
     }
 
+    /**
+     * <p>Getter for the field <code>parentType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     public GraphQLObjectType getParentType() {
         return parentType;
     }
 
+    /**
+     * <p>Getter for the field <code>fields</code>.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, List<Field>> getFields() {
         return fields;
     }
 
+    /**
+     * <p>Getter for the field <code>data</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLExecutionNodeDatum> getData() {
         return data;
     }

--- a/src/main/java/graphql/execution/batched/GraphQLExecutionNodeDatum.java
+++ b/src/main/java/graphql/execution/batched/GraphQLExecutionNodeDatum.java
@@ -6,21 +6,38 @@ class GraphQLExecutionNodeDatum extends GraphQLExecutionResultContainer {
     private final Map<String, Object> parentResult;
     private final Object source;
 
+    /**
+     * <p>Constructor for GraphQLExecutionNodeDatum.</p>
+     *
+     * @param parentResult a {@link java.util.Map} object.
+     * @param source a {@link java.lang.Object} object.
+     */
     public GraphQLExecutionNodeDatum(Map<String, Object> parentResult, Object source) {
         this.parentResult = parentResult;
         this.source = source;
     }
 
+    /**
+     * <p>Getter for the field <code>parentResult</code>.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, Object> getParentResult() {
         return parentResult;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void putResult(String fieldName, Object value) {
         parentResult.put(fieldName, value);
     }
 
+    /**
+     * <p>Getter for the field <code>source</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getSource() {
         return source;
     }

--- a/src/main/java/graphql/execution/batched/GraphQLExecutionNodeValue.java
+++ b/src/main/java/graphql/execution/batched/GraphQLExecutionNodeValue.java
@@ -1,19 +1,40 @@
 package graphql.execution.batched;
 
+/**
+ * <p>GraphQLExecutionNodeValue class.</p>
+ *
+ * @author Andreas Marek
+ */
 public class GraphQLExecutionNodeValue {
 
     private final GraphQLExecutionResultContainer resultContainer;
     private final Object value;
 
+    /**
+     * <p>Constructor for GraphQLExecutionNodeValue.</p>
+     *
+     * @param resultContainer a {@link graphql.execution.batched.GraphQLExecutionResultContainer} object.
+     * @param value a {@link java.lang.Object} object.
+     */
     public GraphQLExecutionNodeValue(GraphQLExecutionResultContainer resultContainer, /*Nullable*/ Object value) {
         this.resultContainer = resultContainer;
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>resultContainer</code>.</p>
+     *
+     * @return a {@link graphql.execution.batched.GraphQLExecutionResultContainer} object.
+     */
     public GraphQLExecutionResultContainer getResultContainer() {
         return resultContainer;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     /*Nullable*/ public Object getValue() {
         return value;
     }

--- a/src/main/java/graphql/execution/batched/GraphQLExecutionResultContainer.java
+++ b/src/main/java/graphql/execution/batched/GraphQLExecutionResultContainer.java
@@ -5,10 +5,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>Abstract GraphQLExecutionResultContainer class.</p>
+ *
+ * @author Andreas Marek
+ */
 public abstract class GraphQLExecutionResultContainer {
 
     /**
      * Creates a child datum which is linked through the results container to this parent.
+     *
+     * @param fieldName a {@link java.lang.String} object.
+     * @param value a {@link java.lang.Object} object.
+     * @return a {@link graphql.execution.batched.GraphQLExecutionNodeDatum} object.
      */
     public GraphQLExecutionNodeDatum createAndPutChildDatum(String fieldName, Object value) {
         Map<String,Object> map = new HashMap<>();
@@ -16,6 +25,12 @@ public abstract class GraphQLExecutionResultContainer {
         return new GraphQLExecutionNodeDatum(map, value);
     }
 
+    /**
+     * <p>createAndPutEmptyChildList.</p>
+     *
+     * @param fieldName a {@link java.lang.String} object.
+     * @return a {@link graphql.execution.batched.GraphQLExecutionResultList} object.
+     */
     public GraphQLExecutionResultList createAndPutEmptyChildList(String fieldName) {
         List<Object> resultList = new ArrayList<>();
         putResult(fieldName, resultList);

--- a/src/main/java/graphql/execution/batched/GraphQLExecutionResultList.java
+++ b/src/main/java/graphql/execution/batched/GraphQLExecutionResultList.java
@@ -2,14 +2,25 @@ package graphql.execution.batched;
 
 import java.util.List;
 
+/**
+ * <p>GraphQLExecutionResultList class.</p>
+ *
+ * @author Andreas Marek
+ */
 public class GraphQLExecutionResultList extends GraphQLExecutionResultContainer {
 
     private final List<Object> results;
 
+    /**
+     * <p>Constructor for GraphQLExecutionResultList.</p>
+     *
+     * @param results a {@link java.util.List} object.
+     */
     public GraphQLExecutionResultList(List<Object> results) {
         this.results = results;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void putResult(String fieldName, Object value) {
         results.add(value);

--- a/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
+++ b/src/main/java/graphql/execution/batched/UnbatchedDataFetcher.java
@@ -11,17 +11,25 @@ import java.util.List;
  * Given a normal data fetcher as a delegate,
  * uses that fetcher in a batched context by iterating through each source value and calling
  * the delegate.
+ *
+ * @author Andreas Marek
  */
 public class UnbatchedDataFetcher implements BatchedDataFetcher {
 
     private final DataFetcher delegate;
 
+    /**
+     * <p>Constructor for UnbatchedDataFetcher.</p>
+     *
+     * @param delegate a {@link graphql.schema.DataFetcher} object.
+     */
     public UnbatchedDataFetcher(DataFetcher delegate) {
         assert !(delegate instanceof BatchedDataFetcher);
         this.delegate = delegate;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public Object get(DataFetchingEnvironment environment) {
         @SuppressWarnings("unchecked")

--- a/src/main/java/graphql/introspection/Introspection.java
+++ b/src/main/java/graphql/introspection/Introspection.java
@@ -12,6 +12,12 @@ import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
 
+/**
+ * <p>Introspection class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Introspection {
 
     public enum TypeKind {
@@ -25,6 +31,7 @@ public class Introspection {
         NON_NULL
     }
 
+    /** Constant <code>__TypeKind</code> */
     public static GraphQLEnumType __TypeKind = GraphQLEnumType.newEnum()
             .name("__TypeKind")
             .description("An enum describing what kind of type a given __Type is")
@@ -38,6 +45,7 @@ public class Introspection {
             .value("NON_NULL", TypeKind.NON_NULL, "Indicates this type is a non-null. `ofType` is a valid field.")
             .build();
 
+    /** Constant <code>kindDataFetcher</code> */
     public static DataFetcher kindDataFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -64,6 +72,7 @@ public class Introspection {
         }
     };
 
+    /** Constant <code>__InputValue</code> */
     public static GraphQLObjectType __InputValue = newObject()
             .name("__InputValue")
             .field(newFieldDefinition()
@@ -98,6 +107,7 @@ public class Introspection {
             .build();
 
 
+    /** Constant <code>__Field</code> */
     public static GraphQLObjectType __Field = newObject()
             .name("__Field")
             .field(newFieldDefinition()
@@ -141,6 +151,7 @@ public class Introspection {
             .build();
 
 
+    /** Constant <code>__EnumValue</code> */
     public static GraphQLObjectType __EnumValue = newObject()
             .name("__EnumValue")
             .field(newFieldDefinition()
@@ -168,6 +179,7 @@ public class Introspection {
                     .build())
             .build();
 
+    /** Constant <code>fieldsFetcher</code> */
     public static DataFetcher fieldsFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -187,6 +199,7 @@ public class Introspection {
         }
     };
 
+    /** Constant <code>interfacesFetcher</code> */
     public static DataFetcher interfacesFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -198,6 +211,7 @@ public class Introspection {
         }
     };
 
+    /** Constant <code>possibleTypesFetcher</code> */
     public static DataFetcher possibleTypesFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -212,6 +226,7 @@ public class Introspection {
         }
     };
 
+    /** Constant <code>enumValuesTypesFetcher</code> */
     public static DataFetcher enumValuesTypesFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -230,6 +245,7 @@ public class Introspection {
         }
     };
 
+    /** Constant <code>inputFieldsFetcher</code> */
     public static DataFetcher inputFieldsFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -241,6 +257,7 @@ public class Introspection {
         }
     };
 
+    /** Constant <code>OfTypeFetcher</code> */
     public static DataFetcher OfTypeFetcher = new DataFetcher() {
         @Override
         public Object get(DataFetchingEnvironment environment) {
@@ -256,6 +273,7 @@ public class Introspection {
     };
 
 
+    /** Constant <code>__Type</code> */
     public static GraphQLObjectType __Type = newObject()
             .name("__Type")
             .field(newFieldDefinition()
@@ -313,6 +331,7 @@ public class Introspection {
                     .build())
             .build();
 
+    /** Constant <code>__Directive</code> */
     public static GraphQLObjectType __Directive = newObject()
             .name("__Directive")
             .field(newFieldDefinition()
@@ -348,6 +367,7 @@ public class Introspection {
                     .build())
             .build();
 
+    /** Constant <code>__Schema</code> */
     public static GraphQLObjectType __Schema = newObject()
             .name("__Schema")
             .description("A GraphQL Introspection defines the capabilities" +
@@ -415,6 +435,7 @@ public class Introspection {
             .build();
 
 
+    /** Constant <code>SchemaMetaFieldDef</code> */
     public static GraphQLFieldDefinition SchemaMetaFieldDef = newFieldDefinition()
             .name("__schema")
             .type(new GraphQLNonNull(__Schema))
@@ -427,6 +448,7 @@ public class Introspection {
             })
             .build();
 
+    /** Constant <code>TypeMetaFieldDef</code> */
     public static GraphQLFieldDefinition TypeMetaFieldDef = newFieldDefinition()
             .name("__type")
             .type(__Type)
@@ -444,6 +466,7 @@ public class Introspection {
             })
             .build();
 
+    /** Constant <code>TypeNameMetaFieldDef</code> */
     public static GraphQLFieldDefinition TypeNameMetaFieldDef = newFieldDefinition()
             .name("__typename")
             .type(new GraphQLNonNull(GraphQLString))

--- a/src/main/java/graphql/language/AbstractNode.java
+++ b/src/main/java/graphql/language/AbstractNode.java
@@ -1,15 +1,27 @@
 package graphql.language;
 
 
+/**
+ * <p>Abstract AbstractNode class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public abstract class AbstractNode implements Node {
 
     private SourceLocation sourceLocation;
 
 
+    /**
+     * <p>Setter for the field <code>sourceLocation</code>.</p>
+     *
+     * @param sourceLocation a {@link graphql.language.SourceLocation} object.
+     */
     public void setSourceLocation(SourceLocation sourceLocation) {
         this.sourceLocation = sourceLocation;
     }
 
+    /** {@inheritDoc} */
     @Override
     public SourceLocation getSourceLocation() {
         return sourceLocation;

--- a/src/main/java/graphql/language/Argument.java
+++ b/src/main/java/graphql/language/Argument.java
@@ -4,33 +4,66 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>Argument class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Argument extends AbstractNode {
 
     private String name;
     private Value value;
 
+    /**
+     * <p>Constructor for Argument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param value a {@link graphql.language.Value} object.
+     */
     public Argument(String name, Value value) {
         this.name = name;
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link graphql.language.Value} object.
+     */
     public Value getValue() {
         return value;
     }
 
+    /**
+     * <p>Setter for the field <code>value</code>.</p>
+     *
+     * @param value a {@link graphql.language.Value} object.
+     */
     public void setValue(Value value) {
         this.value = value;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -39,6 +72,7 @@ public class Argument extends AbstractNode {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -51,6 +85,7 @@ public class Argument extends AbstractNode {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "Argument{" +

--- a/src/main/java/graphql/language/ArrayValue.java
+++ b/src/main/java/graphql/language/ArrayValue.java
@@ -4,31 +4,57 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ArrayValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ArrayValue extends AbstractNode implements Value {
 
     private List<Value> values = new ArrayList<>();
 
+    /**
+     * <p>Constructor for ArrayValue.</p>
+     */
     public ArrayValue() {
     }
 
+    /**
+     * <p>Constructor for ArrayValue.</p>
+     *
+     * @param values a {@link java.util.List} object.
+     */
     public ArrayValue(List<Value> values) {
         this.values = values;
     }
 
+    /**
+     * <p>Getter for the field <code>values</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Value> getValues() {
         return values;
     }
 
+    /**
+     * <p>Setter for the field <code>values</code>.</p>
+     *
+     * @param values a {@link java.util.List} object.
+     */
     public void setValues(List<Value> values) {
         this.values = values;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<Node>(values);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -37,6 +63,7 @@ public class ArrayValue extends AbstractNode implements Value {
         return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "ArrayValue{" +

--- a/src/main/java/graphql/language/AstComparator.java
+++ b/src/main/java/graphql/language/AstComparator.java
@@ -3,9 +3,22 @@ package graphql.language;
 
 import java.util.List;
 
+/**
+ * <p>AstComparator class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class AstComparator {
 
 
+    /**
+     * <p>isEqual.</p>
+     *
+     * @param node1 a {@link graphql.language.Node} object.
+     * @param node2 a {@link graphql.language.Node} object.
+     * @return a boolean.
+     */
     public boolean isEqual(Node node1, Node node2) {
         if (!node1.isEqualTo(node2)) return false;
         List<Node> childs1 = node1.getChildren();

--- a/src/main/java/graphql/language/BooleanValue.java
+++ b/src/main/java/graphql/language/BooleanValue.java
@@ -4,28 +4,51 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>BooleanValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class BooleanValue extends AbstractNode implements Value {
 
     private boolean value;
 
+    /**
+     * <p>Constructor for BooleanValue.</p>
+     *
+     * @param value a boolean.
+     */
     public BooleanValue(boolean value) {
         this.value = value;
     }
 
+    /**
+     * <p>isValue.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isValue() {
         return value;
     }
 
+    /**
+     * <p>Setter for the field <code>value</code>.</p>
+     *
+     * @param value a boolean.
+     */
     public void setValue(boolean value) {
         this.value = value;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -37,6 +60,7 @@ public class BooleanValue extends AbstractNode implements Value {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "BooleanValue{" +

--- a/src/main/java/graphql/language/Definition.java
+++ b/src/main/java/graphql/language/Definition.java
@@ -1,5 +1,11 @@
 package graphql.language;
 
 
+/**
+ * <p>Definition interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface Definition extends Node{
 }

--- a/src/main/java/graphql/language/Directive.java
+++ b/src/main/java/graphql/language/Directive.java
@@ -4,41 +4,78 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>Directive class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Directive extends AbstractNode {
     private String name;
     private final List<Argument> arguments = new ArrayList<>();
 
+    /**
+     * <p>Constructor for Directive.</p>
+     */
     public Directive() {
 
     }
 
+    /**
+     * <p>Constructor for Directive.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public Directive(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Constructor for Directive.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param arguments a {@link java.util.List} object.
+     */
     public Directive(String name, List<Argument> arguments) {
         this.name = name;
         this.arguments.addAll(arguments);
     }
 
+    /**
+     * <p>Getter for the field <code>arguments</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Argument> getArguments() {
         return arguments;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<Node>(arguments);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -50,6 +87,7 @@ public class Directive extends AbstractNode {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "Directive{" +

--- a/src/main/java/graphql/language/Document.java
+++ b/src/main/java/graphql/language/Document.java
@@ -4,33 +4,59 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>Document class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Document extends AbstractNode {
 
     private List<Definition> definitions = new ArrayList<>();
 
+    /**
+     * <p>Constructor for Document.</p>
+     */
     public Document() {
 
     }
 
+    /**
+     * <p>Constructor for Document.</p>
+     *
+     * @param definitions a {@link java.util.List} object.
+     */
     public Document(List<Definition> definitions) {
         this.definitions = definitions;
     }
 
+    /**
+     * <p>Getter for the field <code>definitions</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Definition> getDefinitions() {
         return definitions;
     }
 
+    /**
+     * <p>Setter for the field <code>definitions</code>.</p>
+     *
+     * @param definitions a {@link java.util.List} object.
+     */
     public void setDefinitions(List<Definition> definitions) {
         this.definitions = definitions;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<Node>(definitions);
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -42,6 +68,7 @@ public class Document extends AbstractNode {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "Document{" +

--- a/src/main/java/graphql/language/EnumValue.java
+++ b/src/main/java/graphql/language/EnumValue.java
@@ -4,28 +4,51 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>EnumValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class EnumValue extends AbstractNode implements  Value {
 
     private String name;
 
+    /**
+     * <p>Constructor for EnumValue.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public EnumValue(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -38,6 +61,7 @@ public class EnumValue extends AbstractNode implements  Value {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "EnumValue{" +

--- a/src/main/java/graphql/language/Field.java
+++ b/src/main/java/graphql/language/Field.java
@@ -4,6 +4,12 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>Field class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Field extends AbstractNode implements Selection {
 
     private String name;
@@ -13,31 +19,65 @@ public class Field extends AbstractNode implements Selection {
     private List<Directive> directives = new ArrayList<>();
     private SelectionSet selectionSet;
 
+    /**
+     * <p>Constructor for Field.</p>
+     */
     public Field() {
 
     }
 
+    /**
+     * <p>Constructor for Field.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public Field(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Constructor for Field.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public Field(String name, SelectionSet selectionSet) {
         this.name = name;
         this.selectionSet = selectionSet;
     }
 
 
+    /**
+     * <p>Constructor for Field.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param arguments a {@link java.util.List} object.
+     */
     public Field(String name, List<Argument> arguments) {
         this.name = name;
         this.arguments = arguments;
     }
 
+    /**
+     * <p>Constructor for Field.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param arguments a {@link java.util.List} object.
+     * @param directives a {@link java.util.List} object.
+     */
     public Field(String name, List<Argument> arguments, List<Directive> directives) {
         this.name = name;
         this.arguments = arguments;
         this.directives = directives;
     }
 
+    /**
+     * <p>Constructor for Field.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param arguments a {@link java.util.List} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public Field(String name, List<Argument> arguments, SelectionSet selectionSet) {
         this.name = name;
         this.arguments = arguments;
@@ -45,6 +85,7 @@ public class Field extends AbstractNode implements Selection {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<Node>();
@@ -55,46 +96,97 @@ public class Field extends AbstractNode implements Selection {
     }
 
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>alias</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getAlias() {
         return alias;
     }
 
+    /**
+     * <p>Setter for the field <code>alias</code>.</p>
+     *
+     * @param alias a {@link java.lang.String} object.
+     */
     public void setAlias(String alias) {
         this.alias = alias;
     }
 
+    /**
+     * <p>Getter for the field <code>arguments</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Argument> getArguments() {
         return arguments;
     }
 
+    /**
+     * <p>Setter for the field <code>arguments</code>.</p>
+     *
+     * @param arguments a {@link java.util.List} object.
+     */
     public void setArguments(List<Argument> arguments) {
         this.arguments = arguments;
     }
 
+    /**
+     * <p>Getter for the field <code>directives</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Directive> getDirectives() {
         return directives;
     }
 
+    /**
+     * <p>Setter for the field <code>directives</code>.</p>
+     *
+     * @param directives a {@link java.util.List} object.
+     */
     public void setDirectives(List<Directive> directives) {
         this.directives = directives;
     }
 
+    /**
+     * <p>Getter for the field <code>selectionSet</code>.</p>
+     *
+     * @return a {@link graphql.language.SelectionSet} object.
+     */
     public SelectionSet getSelectionSet() {
         return selectionSet;
     }
 
+    /**
+     * <p>Setter for the field <code>selectionSet</code>.</p>
+     *
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public void setSelectionSet(SelectionSet selectionSet) {
         this.selectionSet = selectionSet;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -108,6 +200,7 @@ public class Field extends AbstractNode implements Selection {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "Field{" +

--- a/src/main/java/graphql/language/FloatValue.java
+++ b/src/main/java/graphql/language/FloatValue.java
@@ -5,28 +5,51 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>FloatValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class FloatValue extends AbstractNode implements Value {
 
     private BigDecimal value;
 
+    /**
+     * <p>Constructor for FloatValue.</p>
+     *
+     * @param value a {@link java.math.BigDecimal} object.
+     */
     public FloatValue(BigDecimal value) {
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link java.math.BigDecimal} object.
+     */
     public BigDecimal getValue() {
         return value;
     }
 
+    /**
+     * <p>Setter for the field <code>value</code>.</p>
+     *
+     * @param value a {@link java.math.BigDecimal} object.
+     */
     public void setValue(BigDecimal value) {
         this.value = value;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "FloatValue{" +
@@ -34,6 +57,7 @@ public class FloatValue extends AbstractNode implements Value {
                 '}';
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;

--- a/src/main/java/graphql/language/FragmentDefinition.java
+++ b/src/main/java/graphql/language/FragmentDefinition.java
@@ -4,6 +4,12 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>FragmentDefinition class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class FragmentDefinition extends AbstractNode implements Definition {
 
     private String name;
@@ -11,15 +17,31 @@ public class FragmentDefinition extends AbstractNode implements Definition {
     private List<Directive> directives = new ArrayList<>();
     private SelectionSet selectionSet;
 
+    /**
+     * <p>Constructor for FragmentDefinition.</p>
+     */
     public FragmentDefinition() {
 
     }
 
+    /**
+     * <p>Constructor for FragmentDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     */
     public FragmentDefinition(String name, TypeName typeCondition) {
         this.name = name;
         this.typeCondition = typeCondition;
     }
 
+    /**
+     * <p>Constructor for FragmentDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public FragmentDefinition(String name, TypeName typeCondition, SelectionSet selectionSet) {
         this.name = name;
         this.typeCondition = typeCondition;
@@ -27,38 +49,79 @@ public class FragmentDefinition extends AbstractNode implements Definition {
     }
 
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>typeCondition</code>.</p>
+     *
+     * @return a {@link graphql.language.TypeName} object.
+     */
     public TypeName getTypeCondition() {
         return typeCondition;
     }
 
+    /**
+     * <p>Setter for the field <code>typeCondition</code>.</p>
+     *
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     */
     public void setTypeCondition(TypeName typeCondition) {
         this.typeCondition = typeCondition;
     }
 
+    /**
+     * <p>Getter for the field <code>directives</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Directive> getDirectives() {
         return directives;
     }
 
+    /**
+     * <p>Setter for the field <code>directives</code>.</p>
+     *
+     * @param directives a {@link java.util.List} object.
+     */
     public void setDirectives(List<Directive> directives) {
         this.directives = directives;
     }
 
+    /**
+     * <p>Getter for the field <code>selectionSet</code>.</p>
+     *
+     * @return a {@link graphql.language.SelectionSet} object.
+     */
     public SelectionSet getSelectionSet() {
         return selectionSet;
     }
 
+    /**
+     * <p>Setter for the field <code>selectionSet</code>.</p>
+     *
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public void setSelectionSet(SelectionSet selectionSet) {
         this.selectionSet = selectionSet;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -68,6 +131,7 @@ public class FragmentDefinition extends AbstractNode implements Definition {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -80,6 +144,7 @@ public class FragmentDefinition extends AbstractNode implements Definition {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "FragmentDefinition{" +

--- a/src/main/java/graphql/language/FragmentSpread.java
+++ b/src/main/java/graphql/language/FragmentSpread.java
@@ -4,34 +4,69 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>FragmentSpread class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class FragmentSpread extends AbstractNode implements Selection {
 
     private String name;
     private List<Directive> directives = new ArrayList<>();
 
+    /**
+     * <p>Constructor for FragmentSpread.</p>
+     */
     public FragmentSpread() {
     }
 
+    /**
+     * <p>Constructor for FragmentSpread.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public FragmentSpread(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>directives</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Directive> getDirectives() {
         return directives;
     }
 
+    /**
+     * <p>Setter for the field <code>directives</code>.</p>
+     *
+     * @param directives a {@link java.util.List} object.
+     */
     public void setDirectives(List<Directive> directives) {
         this.directives = directives;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -44,6 +79,7 @@ public class FragmentSpread extends AbstractNode implements Selection {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -51,6 +87,7 @@ public class FragmentSpread extends AbstractNode implements Selection {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "FragmentSpread{" +

--- a/src/main/java/graphql/language/InlineFragment.java
+++ b/src/main/java/graphql/language/InlineFragment.java
@@ -4,55 +4,113 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>InlineFragment class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class InlineFragment extends AbstractNode implements Selection {
     private TypeName typeCondition;
     private List<Directive> directives = new ArrayList<>();
     private SelectionSet selectionSet;
 
+    /**
+     * <p>Constructor for InlineFragment.</p>
+     */
     public InlineFragment() {
 
     }
 
+    /**
+     * <p>Constructor for InlineFragment.</p>
+     *
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     */
     public InlineFragment(TypeName typeCondition) {
         this.typeCondition = typeCondition;
     }
 
+    /**
+     * <p>Constructor for InlineFragment.</p>
+     *
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     * @param directives a {@link java.util.List} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public InlineFragment(TypeName typeCondition, List<Directive> directives, SelectionSet selectionSet) {
         this.typeCondition = typeCondition;
         this.directives = directives;
         this.selectionSet = selectionSet;
     }
 
+    /**
+     * <p>Constructor for InlineFragment.</p>
+     *
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public InlineFragment(TypeName typeCondition, SelectionSet selectionSet) {
         this.typeCondition = typeCondition;
         this.selectionSet = selectionSet;
     }
 
 
+    /**
+     * <p>Getter for the field <code>typeCondition</code>.</p>
+     *
+     * @return a {@link graphql.language.TypeName} object.
+     */
     public TypeName getTypeCondition() {
         return typeCondition;
     }
 
+    /**
+     * <p>Setter for the field <code>typeCondition</code>.</p>
+     *
+     * @param typeCondition a {@link graphql.language.TypeName} object.
+     */
     public void setTypeCondition(TypeName typeCondition) {
         this.typeCondition = typeCondition;
     }
 
+    /**
+     * <p>Getter for the field <code>directives</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Directive> getDirectives() {
         return directives;
     }
 
+    /**
+     * <p>Setter for the field <code>directives</code>.</p>
+     *
+     * @param directives a {@link java.util.List} object.
+     */
     public void setDirectives(List<Directive> directives) {
         this.directives = directives;
     }
 
+    /**
+     * <p>Getter for the field <code>selectionSet</code>.</p>
+     *
+     * @return a {@link graphql.language.SelectionSet} object.
+     */
     public SelectionSet getSelectionSet() {
         return selectionSet;
     }
 
+    /**
+     * <p>Setter for the field <code>selectionSet</code>.</p>
+     *
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public void setSelectionSet(SelectionSet selectionSet) {
         this.selectionSet = selectionSet;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -62,6 +120,7 @@ public class InlineFragment extends AbstractNode implements Selection {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -72,6 +131,7 @@ public class InlineFragment extends AbstractNode implements Selection {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "InlineFragment{" +

--- a/src/main/java/graphql/language/IntValue.java
+++ b/src/main/java/graphql/language/IntValue.java
@@ -4,27 +4,50 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>IntValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class IntValue extends AbstractNode implements Value {
 
     private int value;
 
+    /**
+     * <p>Constructor for IntValue.</p>
+     *
+     * @param value a int.
+     */
     public IntValue(int value) {
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a int.
+     */
     public int getValue() {
         return value;
     }
 
+    /**
+     * <p>Setter for the field <code>value</code>.</p>
+     *
+     * @param value a int.
+     */
     public void setValue(int value) {
         this.value = value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -37,6 +60,7 @@ public class IntValue extends AbstractNode implements Value {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "IntValue{" +

--- a/src/main/java/graphql/language/ListType.java
+++ b/src/main/java/graphql/language/ListType.java
@@ -4,25 +4,50 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ListType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ListType extends AbstractNode implements Type {
 
     private Type type;
 
+    /**
+     * <p>Constructor for ListType.</p>
+     */
     public ListType() {
     }
 
+    /**
+     * <p>Constructor for ListType.</p>
+     *
+     * @param type a {@link graphql.language.Type} object.
+     */
     public ListType(Type type) {
         this.type = type;
     }
 
+    /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
+     * @return a {@link graphql.language.Type} object.
+     */
     public Type getType() {
         return type;
     }
 
+    /**
+     * <p>Setter for the field <code>type</code>.</p>
+     *
+     * @param type a {@link graphql.language.Type} object.
+     */
     public void setType(Type type) {
         this.type = type;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -30,6 +55,7 @@ public class ListType extends AbstractNode implements Type {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -39,6 +65,7 @@ public class ListType extends AbstractNode implements Type {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "ListType{" +

--- a/src/main/java/graphql/language/Node.java
+++ b/src/main/java/graphql/language/Node.java
@@ -3,16 +3,33 @@ package graphql.language;
 
 import java.util.List;
 
+/**
+ * <p>Node interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface Node {
 
+    /**
+     * <p>getChildren.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     List<Node> getChildren();
 
+    /**
+     * <p>getSourceLocation.</p>
+     *
+     * @return a {@link graphql.language.SourceLocation} object.
+     */
     SourceLocation getSourceLocation();
 
     /**
      * Compares just the content and not the children.
-     * @param node
-     * @return
+     *
+     * @param node a {@link graphql.language.Node} object.
+     * @return a boolean.
      */
     boolean isEqualTo(Node node);
 }

--- a/src/main/java/graphql/language/NonNullType.java
+++ b/src/main/java/graphql/language/NonNullType.java
@@ -4,29 +4,59 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>NonNullType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class NonNullType extends AbstractNode implements Type {
 
     private Type type;
 
+    /**
+     * <p>Constructor for NonNullType.</p>
+     */
     public NonNullType() {
     }
 
+    /**
+     * <p>Constructor for NonNullType.</p>
+     *
+     * @param type a {@link graphql.language.Type} object.
+     */
     public NonNullType(Type type) {
         this.type = type;
     }
 
+    /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
+     * @return a {@link graphql.language.Type} object.
+     */
     public Type getType() {
         return type;
     }
 
+    /**
+     * <p>Setter for the field <code>type</code>.</p>
+     *
+     * @param type a {@link graphql.language.ListType} object.
+     */
     public void setType(ListType type) {
         this.type = type;
     }
 
+    /**
+     * <p>Setter for the field <code>type</code>.</p>
+     *
+     * @param type a {@link graphql.language.TypeName} object.
+     */
     public void setType(TypeName type) {
         this.type = type;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -34,6 +64,7 @@ public class NonNullType extends AbstractNode implements Type {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -43,6 +74,7 @@ public class NonNullType extends AbstractNode implements Type {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "NonNullType{" +

--- a/src/main/java/graphql/language/ObjectField.java
+++ b/src/main/java/graphql/language/ObjectField.java
@@ -4,24 +4,47 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ObjectField class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ObjectField extends AbstractNode {
 
     private String name;
     private Value value;
 
+    /**
+     * <p>Constructor for ObjectField.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param value a {@link graphql.language.Value} object.
+     */
     public ObjectField(String name, Value value) {
         this.name = name;
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link graphql.language.Value} object.
+     */
     public Value getValue() {
         return value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -29,6 +52,7 @@ public class ObjectField extends AbstractNode {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -40,6 +64,7 @@ public class ObjectField extends AbstractNode {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "ObjectField{" +

--- a/src/main/java/graphql/language/ObjectValue.java
+++ b/src/main/java/graphql/language/ObjectValue.java
@@ -4,21 +4,41 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ObjectValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ObjectValue extends AbstractNode implements Value {
 
     private List<ObjectField> objectFields = new ArrayList<>();
 
+    /**
+     * <p>Constructor for ObjectValue.</p>
+     */
     public ObjectValue() {
     }
 
+    /**
+     * <p>Constructor for ObjectValue.</p>
+     *
+     * @param objectFields a {@link java.util.List} object.
+     */
     public ObjectValue(List<ObjectField> objectFields) {
         this.objectFields.addAll(objectFields);
     }
 
+    /**
+     * <p>Getter for the field <code>objectFields</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<ObjectField> getObjectFields() {
         return objectFields;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -26,6 +46,7 @@ public class ObjectValue extends AbstractNode implements Value {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -38,6 +59,7 @@ public class ObjectValue extends AbstractNode implements Value {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "ObjectValue{" +

--- a/src/main/java/graphql/language/OperationDefinition.java
+++ b/src/main/java/graphql/language/OperationDefinition.java
@@ -4,6 +4,12 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>OperationDefinition class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class OperationDefinition extends AbstractNode implements Definition {
 
     public enum Operation {
@@ -17,10 +23,22 @@ public class OperationDefinition extends AbstractNode implements Definition {
     private List<Directive> directives = new ArrayList<>();
     private SelectionSet selectionSet;
 
+    /**
+     * <p>Constructor for OperationDefinition.</p>
+     */
     public OperationDefinition() {
 
     }
 
+    /**
+     * <p>Constructor for OperationDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param operation a {@link graphql.language.OperationDefinition.Operation} object.
+     * @param variableDefinitions a {@link java.util.List} object.
+     * @param directives a {@link java.util.List} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public OperationDefinition(String name, Operation operation, List<VariableDefinition> variableDefinitions, List<Directive> directives, SelectionSet selectionSet) {
         this.name = name;
         this.operation = operation;
@@ -29,6 +47,14 @@ public class OperationDefinition extends AbstractNode implements Definition {
         this.selectionSet = selectionSet;
     }
 
+    /**
+     * <p>Constructor for OperationDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param operation a {@link graphql.language.OperationDefinition.Operation} object.
+     * @param variableDefinitions a {@link java.util.List} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public OperationDefinition(String name, Operation operation, List<VariableDefinition> variableDefinitions, SelectionSet selectionSet) {
         this.name = name;
         this.operation = operation;
@@ -36,12 +62,20 @@ public class OperationDefinition extends AbstractNode implements Definition {
         this.selectionSet = selectionSet;
     }
 
+    /**
+     * <p>Constructor for OperationDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param operation a {@link graphql.language.OperationDefinition.Operation} object.
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public OperationDefinition(String name, Operation operation, SelectionSet selectionSet) {
         this.name = name;
         this.operation = operation;
         this.selectionSet = selectionSet;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -51,47 +85,98 @@ public class OperationDefinition extends AbstractNode implements Definition {
         return result;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>operation</code>.</p>
+     *
+     * @return a {@link graphql.language.OperationDefinition.Operation} object.
+     */
     public Operation getOperation() {
         return operation;
     }
 
+    /**
+     * <p>Setter for the field <code>operation</code>.</p>
+     *
+     * @param operation a {@link graphql.language.OperationDefinition.Operation} object.
+     */
     public void setOperation(Operation operation) {
         this.operation = operation;
     }
 
+    /**
+     * <p>Getter for the field <code>variableDefinitions</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<VariableDefinition> getVariableDefinitions() {
         return variableDefinitions;
     }
 
+    /**
+     * <p>Setter for the field <code>variableDefinitions</code>.</p>
+     *
+     * @param variableDefinitions a {@link java.util.List} object.
+     */
     public void setVariableDefinitions(List<VariableDefinition> variableDefinitions) {
         this.variableDefinitions = variableDefinitions;
     }
 
+    /**
+     * <p>Getter for the field <code>directives</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Directive> getDirectives() {
         return directives;
     }
 
+    /**
+     * <p>Setter for the field <code>directives</code>.</p>
+     *
+     * @param directives a {@link java.util.List} object.
+     */
     public void setDirectives(List<Directive> directives) {
         this.directives = directives;
     }
 
+    /**
+     * <p>Getter for the field <code>selectionSet</code>.</p>
+     *
+     * @return a {@link graphql.language.SelectionSet} object.
+     */
     public SelectionSet getSelectionSet() {
         return selectionSet;
     }
 
+    /**
+     * <p>Setter for the field <code>selectionSet</code>.</p>
+     *
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public void setSelectionSet(SelectionSet selectionSet) {
         this.selectionSet = selectionSet;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -104,6 +189,7 @@ public class OperationDefinition extends AbstractNode implements Definition {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "OperationDefinition{" +

--- a/src/main/java/graphql/language/Selection.java
+++ b/src/main/java/graphql/language/Selection.java
@@ -1,5 +1,11 @@
 package graphql.language;
 
 
+/**
+ * <p>Selection interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface Selection extends Node{
 }

--- a/src/main/java/graphql/language/SelectionSet.java
+++ b/src/main/java/graphql/language/SelectionSet.java
@@ -4,21 +4,41 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>SelectionSet class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class SelectionSet extends AbstractNode{
 
     private final List<Selection> selections = new ArrayList<>();
 
+    /**
+     * <p>Getter for the field <code>selections</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Selection> getSelections() {
         return selections;
     }
 
+    /**
+     * <p>Constructor for SelectionSet.</p>
+     */
     public SelectionSet() {
     }
 
+    /**
+     * <p>Constructor for SelectionSet.</p>
+     *
+     * @param selections a {@link java.util.List} object.
+     */
     public SelectionSet(List<Selection> selections) {
         this.selections.addAll(selections);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -26,6 +46,7 @@ public class SelectionSet extends AbstractNode{
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -38,6 +59,7 @@ public class SelectionSet extends AbstractNode{
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "SelectionSet{" +

--- a/src/main/java/graphql/language/SourceLocation.java
+++ b/src/main/java/graphql/language/SourceLocation.java
@@ -1,24 +1,47 @@
 package graphql.language;
 
 
+/**
+ * <p>SourceLocation class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class SourceLocation {
 
     private final int line;
     private final int column;
 
+    /**
+     * <p>Constructor for SourceLocation.</p>
+     *
+     * @param line a int.
+     * @param column a int.
+     */
     public SourceLocation(int line, int column) {
         this.line = line;
         this.column = column;
     }
 
+    /**
+     * <p>Getter for the field <code>line</code>.</p>
+     *
+     * @return a int.
+     */
     public int getLine() {
         return line;
     }
 
+    /**
+     * <p>Getter for the field <code>column</code>.</p>
+     *
+     * @return a int.
+     */
     public int getColumn() {
         return column;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -31,6 +54,7 @@ public class SourceLocation {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         int result = line;
@@ -38,6 +62,7 @@ public class SourceLocation {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "SourceLocation{" +

--- a/src/main/java/graphql/language/StringValue.java
+++ b/src/main/java/graphql/language/StringValue.java
@@ -4,28 +4,51 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>StringValue class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class StringValue extends AbstractNode implements Value {
 
     private String value;
 
+    /**
+     * <p>Constructor for StringValue.</p>
+     *
+     * @param value a {@link java.lang.String} object.
+     */
     public StringValue(String value) {
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getValue() {
         return value;
     }
 
+    /**
+     * <p>Setter for the field <code>value</code>.</p>
+     *
+     * @param value a {@link java.lang.String} object.
+     */
     public void setValue(String value) {
         this.value = value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "StringValue{" +
@@ -33,6 +56,7 @@ public class StringValue extends AbstractNode implements Value {
                 '}';
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;

--- a/src/main/java/graphql/language/Type.java
+++ b/src/main/java/graphql/language/Type.java
@@ -1,5 +1,11 @@
 package graphql.language;
 
 
+/**
+ * <p>Type interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface Type extends Node{
 }

--- a/src/main/java/graphql/language/TypeName.java
+++ b/src/main/java/graphql/language/TypeName.java
@@ -4,27 +4,50 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>TypeName class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class TypeName extends AbstractNode implements Type {
 
     private String name;
 
+    /**
+     * <p>Constructor for TypeName.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public TypeName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -38,6 +61,7 @@ public class TypeName extends AbstractNode implements Type {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "TypeName{" +

--- a/src/main/java/graphql/language/Value.java
+++ b/src/main/java/graphql/language/Value.java
@@ -1,5 +1,11 @@
 package graphql.language;
 
 
+/**
+ * <p>Value interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface Value extends Node{
 }

--- a/src/main/java/graphql/language/VariableDefinition.java
+++ b/src/main/java/graphql/language/VariableDefinition.java
@@ -4,52 +4,105 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>VariableDefinition class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class VariableDefinition extends AbstractNode {
 
     private String name;
     private Type type;
     private Value defaultValue;
 
+    /**
+     * <p>Constructor for VariableDefinition.</p>
+     */
     public VariableDefinition() {
 
     }
 
 
+    /**
+     * <p>Constructor for VariableDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param type a {@link graphql.language.Type} object.
+     */
     public VariableDefinition(String name, Type type) {
         this.name = name;
         this.type = type;
     }
 
+    /**
+     * <p>Constructor for VariableDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param type a {@link graphql.language.Type} object.
+     * @param defaultValue a {@link graphql.language.Value} object.
+     */
     public VariableDefinition(String name, Type type, Value defaultValue) {
         this.name = name;
         this.type = type;
         this.defaultValue = defaultValue;
     }
 
+    /**
+     * <p>Getter for the field <code>defaultValue</code>.</p>
+     *
+     * @return a {@link graphql.language.Value} object.
+     */
     public Value getDefaultValue() {
         return defaultValue;
     }
 
+    /**
+     * <p>Setter for the field <code>defaultValue</code>.</p>
+     *
+     * @param defaultValue a {@link graphql.language.Value} object.
+     */
     public void setDefaultValue(Value defaultValue) {
         this.defaultValue = defaultValue;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
+     * @return a {@link graphql.language.Type} object.
+     */
     public Type getType() {
         return type;
     }
 
+    /**
+     * <p>Setter for the field <code>type</code>.</p>
+     *
+     * @param type a {@link graphql.language.Type} object.
+     */
     public void setType(Type type) {
         this.type = type;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         List<Node> result = new ArrayList<>();
@@ -58,6 +111,7 @@ public class VariableDefinition extends AbstractNode {
         return result;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -70,6 +124,7 @@ public class VariableDefinition extends AbstractNode {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "VariableDefinition{" +

--- a/src/main/java/graphql/language/VariableReference.java
+++ b/src/main/java/graphql/language/VariableReference.java
@@ -4,27 +4,50 @@ package graphql.language;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>VariableReference class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class VariableReference extends AbstractNode implements Value {
 
     private String name;
 
+    /**
+     * <p>Constructor for VariableReference.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public VariableReference(String name) {
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Setter for the field <code>name</code>.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<Node> getChildren() {
         return new ArrayList<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isEqualTo(Node o) {
         if (this == o) return true;
@@ -36,6 +59,7 @@ public class VariableReference extends AbstractNode implements Value {
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "VariableReference{" +

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -11,6 +11,12 @@ import java.math.BigDecimal;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
+/**
+ * <p>GraphqlAntlrToLanguage class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
     Document result;
@@ -95,6 +101,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public Void visitDocument( GraphqlParser.DocumentContext ctx) {
         result = new Document();
@@ -102,6 +109,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return super.visitDocument(ctx);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitOperationDefinition( GraphqlParser.OperationDefinitionContext ctx) {
         OperationDefinition operationDefinition;
@@ -134,6 +142,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitFragmentSpread( GraphqlParser.FragmentSpreadContext ctx) {
         FragmentSpread fragmentSpread = new FragmentSpread(ctx.fragmentName().getText());
@@ -145,6 +154,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitVariableDefinition( GraphqlParser.VariableDefinitionContext ctx) {
         VariableDefinition variableDefinition = new VariableDefinition();
@@ -163,6 +173,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitFragmentDefinition( GraphqlParser.FragmentDefinitionContext ctx) {
         FragmentDefinition fragmentDefinition = new FragmentDefinition();
@@ -177,6 +188,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public Void visitSelectionSet( GraphqlParser.SelectionSetContext ctx) {
         SelectionSet newSelectionSet = new SelectionSet();
@@ -188,6 +200,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public Void visitField( GraphqlParser.FieldContext ctx) {
         Field newField = new Field();
@@ -202,6 +215,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitTypeName( GraphqlParser.TypeNameContext ctx) {
         TypeName typeName = new TypeName(ctx.NAME().getText());
@@ -223,6 +237,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return super.visitTypeName(ctx);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitNonNullType( GraphqlParser.NonNullTypeContext ctx) {
         NonNullType nonNullType = new NonNullType();
@@ -243,6 +258,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitListType( GraphqlParser.ListTypeContext ctx) {
         ListType listType = new ListType();
@@ -267,6 +283,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitArgument( GraphqlParser.ArgumentContext ctx) {
         Argument argument = new Argument(ctx.NAME().getText(), getValue(ctx.valueWithVariable()));
@@ -280,6 +297,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return super.visitArgument(ctx);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitInlineFragment( GraphqlParser.InlineFragmentContext ctx) {
         InlineFragment inlineFragment = new InlineFragment(new TypeName(ctx.typeCondition().getText()));
@@ -291,6 +309,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Void visitDirective( GraphqlParser.DirectiveContext ctx) {
         Directive directive = new Directive(ctx.NAME().getText());

--- a/src/main/java/graphql/parser/Parser.java
+++ b/src/main/java/graphql/parser/Parser.java
@@ -10,11 +10,23 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * <p>Parser class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Parser {
 
     private static final Logger log = LoggerFactory.getLogger(Parser.class);
 
 
+    /**
+     * <p>parseDocument.</p>
+     *
+     * @param input a {@link java.lang.String} object.
+     * @return a {@link graphql.language.Document} object.
+     */
     public Document parseDocument(String input) {
 
         GraphqlLexer lexer = new GraphqlLexer(new ANTLRInputStream(input));

--- a/src/main/java/graphql/parser/antlr/GraphqlBaseListener.java
+++ b/src/main/java/graphql/parser/antlr/GraphqlBaseListener.java
@@ -7,9 +7,12 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 /**
- * This class provides an empty implementation of {@link GraphqlListener},
+ * This class provides an empty implementation of {@link graphql.parser.antlr.GraphqlListener},
  * which can be extended to create a listener which only needs to handle a subset
  * of the available methods.
+ *
+ * @author Andreas Marek
+ * @version v1.0
  */
 public class GraphqlBaseListener implements GraphqlListener {
 	/**

--- a/src/main/java/graphql/parser/antlr/GraphqlBaseVisitor.java
+++ b/src/main/java/graphql/parser/antlr/GraphqlBaseVisitor.java
@@ -3,12 +3,14 @@ package graphql.parser.antlr;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 
 /**
- * This class provides an empty implementation of {@link GraphqlVisitor},
+ * This class provides an empty implementation of {@link graphql.parser.antlr.GraphqlVisitor},
  * which can be extended to create a visitor which only needs to handle a subset
  * of the available methods.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
+ * @param <T> The return type of the visit operation. Use {@link java.lang.Void} for
  * operations with no return type.
+ * @author Andreas Marek
+ * @version v1.0
  */
 public class GraphqlBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements GraphqlVisitor<T> {
 	/**

--- a/src/main/java/graphql/parser/antlr/GraphqlLexer.java
+++ b/src/main/java/graphql/parser/antlr/GraphqlLexer.java
@@ -8,22 +8,59 @@ import org.antlr.v4.runtime.atn.LexerATNSimulator;
 import org.antlr.v4.runtime.atn.PredictionContextCache;
 import org.antlr.v4.runtime.dfa.DFA;
 
+/**
+ * <p>GraphqlLexer class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class GraphqlLexer extends Lexer {
 	static { RuntimeMetaData.checkVersion("4.5.1", RuntimeMetaData.VERSION); }
 
+	/** Constant <code>_decisionToDFA</code> */
 	protected static final DFA[] _decisionToDFA;
+	/** Constant <code>_sharedContextCache</code> */
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
+	/** Constant <code>T__0=1</code> */
 	public static final int
+		/** Constant <code>T__1=2</code> */
+		/** Constant <code>T__2=3</code> */
+		/** Constant <code>T__3=4</code> */
+		/** Constant <code>T__4=5</code> */
+		/** Constant <code>T__5=6</code> */
+		/** Constant <code>T__6=7</code> */
+		/** Constant <code>T__7=8</code> */
+		/** Constant <code>T__8=9</code> */
 		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9, 
+		/** Constant <code>T__9=10</code> */
+		/** Constant <code>T__10=11</code> */
+		/** Constant <code>T__11=12</code> */
+		/** Constant <code>T__12=13</code> */
+		/** Constant <code>T__13=14</code> */
+		/** Constant <code>T__14=15</code> */
+		/** Constant <code>T__15=16</code> */
+		/** Constant <code>BooleanValue=17</code> */
 		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, BooleanValue=17, 
+		/** Constant <code>NAME=18</code> */
+		/** Constant <code>IntValue=19</code> */
+		/** Constant <code>FloatValue=20</code> */
+		/** Constant <code>Sign=21</code> */
+		/** Constant <code>IntegerPart=22</code> */
+		/** Constant <code>NonZeroDigit=23</code> */
 		NAME=18, IntValue=19, FloatValue=20, Sign=21, IntegerPart=22, NonZeroDigit=23, 
+		/** Constant <code>ExponentPart=24</code> */
+		/** Constant <code>Digit=25</code> */
+		/** Constant <code>StringValue=26</code> */
+		/** Constant <code>Ignored=27</code> */
 		ExponentPart=24, Digit=25, StringValue=26, Ignored=27;
+	/** Constant <code>modeNames="{DEFAULT_MODE}"</code> */
 	public static String[] modeNames = {
 		"DEFAULT_MODE"
 	};
 
+	/** Constant <code>ruleNames="{T__0, T__1, T__2, T__3, T__4, T__5, T_"{trunked}</code> */
 	public static final String[] ruleNames = {
 		"T__0", "T__1", "T__2", "T__3", "T__4", "T__5", "T__6", "T__7", "T__8", 
 		"T__9", "T__10", "T__11", "T__12", "T__13", "T__14", "T__15", "BooleanValue", 
@@ -43,6 +80,7 @@ public class GraphqlLexer extends Lexer {
 		"Sign", "IntegerPart", "NonZeroDigit", "ExponentPart", "Digit", "StringValue", 
 		"Ignored"
 	};
+	/** Constant <code>VOCABULARY</code> */
 	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
 	/**
@@ -64,12 +102,14 @@ public class GraphqlLexer extends Lexer {
 		}
 	}
 
+	/** {@inheritDoc} */
 	@Override
 	@Deprecated
 	public String[] getTokenNames() {
 		return tokenNames;
 	}
 
+	/** {@inheritDoc} */
 	@Override
 
 	public Vocabulary getVocabulary() {
@@ -77,26 +117,37 @@ public class GraphqlLexer extends Lexer {
 	}
 
 
+	/**
+	 * <p>Constructor for GraphqlLexer.</p>
+	 *
+	 * @param input a {@link org.antlr.v4.runtime.CharStream} object.
+	 */
 	public GraphqlLexer(CharStream input) {
 		super(input);
 		_interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
 	}
 
+	/** {@inheritDoc} */
 	@Override
 	public String getGrammarFileName() { return "Graphql.g4"; }
 
+	/** {@inheritDoc} */
 	@Override
 	public String[] getRuleNames() { return ruleNames; }
 
+	/** {@inheritDoc} */
 	@Override
 	public String getSerializedATN() { return _serializedATN; }
 
+	/** {@inheritDoc} */
 	@Override
 	public String[] getModeNames() { return modeNames; }
 
+	/** {@inheritDoc} */
 	@Override
 	public ATN getATN() { return _ATN; }
 
+	/** Constant <code>_serializedATN="\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\"{trunked}</code> */
 	public static final String _serializedATN =
 		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\2\35\u00e7\b\1\4\2"+
 		"\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4"+
@@ -175,6 +226,7 @@ public class GraphqlLexer extends Lexer {
 		"\u00e2B\3\2\2\2\u00e3\u00e4\t\t\2\2\u00e4D\3\2\2\2\u00e5\u00e6\7.\2\2"+
 		"\u00e6F\3\2\2\2\23\2\u0085\u008b\u008f\u0094\u009b\u009d\u00a0\u00aa\u00ac"+
 		"\u00b2\u00b7\u00be\u00c0\u00c8\u00d6\u00de\3\b\2\2";
+	/** Constant <code>_ATN</code> */
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {

--- a/src/main/java/graphql/parser/antlr/GraphqlListener.java
+++ b/src/main/java/graphql/parser/antlr/GraphqlListener.java
@@ -5,346 +5,417 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 
 /**
  * This interface defines a complete listener for a parse tree produced by
- * {@link GraphqlParser}.
+ * {@link graphql.parser.antlr.GraphqlParser}.
+ *
+ * @author Andreas Marek
+ * @version v1.0
  */
 public interface GraphqlListener extends ParseTreeListener {
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#document}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#document}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterDocument(@NotNull GraphqlParser.DocumentContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#document}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#document}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitDocument(@NotNull GraphqlParser.DocumentContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#definition}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#definition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterDefinition(@NotNull GraphqlParser.DefinitionContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#definition}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#definition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitDefinition(@NotNull GraphqlParser.DefinitionContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#operationDefinition}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#operationDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterOperationDefinition(@NotNull GraphqlParser.OperationDefinitionContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#operationDefinition}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#operationDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitOperationDefinition(@NotNull GraphqlParser.OperationDefinitionContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#operationType}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#operationType}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterOperationType(@NotNull GraphqlParser.OperationTypeContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#operationType}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#operationType}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitOperationType(@NotNull GraphqlParser.OperationTypeContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#variableDefinitions}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variableDefinitions}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterVariableDefinitions(@NotNull GraphqlParser.VariableDefinitionsContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#variableDefinitions}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variableDefinitions}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitVariableDefinitions(@NotNull GraphqlParser.VariableDefinitionsContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#variableDefinition}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variableDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterVariableDefinition(@NotNull GraphqlParser.VariableDefinitionContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#variableDefinition}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variableDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitVariableDefinition(@NotNull GraphqlParser.VariableDefinitionContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#variable}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterVariable(@NotNull GraphqlParser.VariableContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#variable}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitVariable(@NotNull GraphqlParser.VariableContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#defaultValue}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#defaultValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterDefaultValue(@NotNull GraphqlParser.DefaultValueContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#defaultValue}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#defaultValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitDefaultValue(@NotNull GraphqlParser.DefaultValueContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#selectionSet}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#selectionSet}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterSelectionSet(@NotNull GraphqlParser.SelectionSetContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#selectionSet}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#selectionSet}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitSelectionSet(@NotNull GraphqlParser.SelectionSetContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#selection}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#selection}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterSelection(@NotNull GraphqlParser.SelectionContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#selection}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#selection}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitSelection(@NotNull GraphqlParser.SelectionContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#field}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#field}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterField(@NotNull GraphqlParser.FieldContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#field}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#field}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitField(@NotNull GraphqlParser.FieldContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#alias}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#alias}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterAlias(@NotNull GraphqlParser.AliasContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#alias}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#alias}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitAlias(@NotNull GraphqlParser.AliasContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#arguments}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arguments}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterArguments(@NotNull GraphqlParser.ArgumentsContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#arguments}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arguments}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitArguments(@NotNull GraphqlParser.ArgumentsContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#argument}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#argument}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterArgument(@NotNull GraphqlParser.ArgumentContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#argument}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#argument}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitArgument(@NotNull GraphqlParser.ArgumentContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#fragmentSpread}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentSpread}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterFragmentSpread(@NotNull GraphqlParser.FragmentSpreadContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#fragmentSpread}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentSpread}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitFragmentSpread(@NotNull GraphqlParser.FragmentSpreadContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#inlineFragment}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#inlineFragment}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterInlineFragment(@NotNull GraphqlParser.InlineFragmentContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#inlineFragment}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#inlineFragment}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitInlineFragment(@NotNull GraphqlParser.InlineFragmentContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#fragmentDefinition}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterFragmentDefinition(@NotNull GraphqlParser.FragmentDefinitionContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#fragmentDefinition}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitFragmentDefinition(@NotNull GraphqlParser.FragmentDefinitionContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#fragmentName}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentName}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterFragmentName(@NotNull GraphqlParser.FragmentNameContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#fragmentName}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentName}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitFragmentName(@NotNull GraphqlParser.FragmentNameContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#typeCondition}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#typeCondition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterTypeCondition(@NotNull GraphqlParser.TypeConditionContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#typeCondition}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#typeCondition}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitTypeCondition(@NotNull GraphqlParser.TypeConditionContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#value}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#value}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterValue(@NotNull GraphqlParser.ValueContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#value}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#value}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitValue(@NotNull GraphqlParser.ValueContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#valueWithVariable}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#valueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterValueWithVariable(@NotNull GraphqlParser.ValueWithVariableContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#valueWithVariable}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#valueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitValueWithVariable(@NotNull GraphqlParser.ValueWithVariableContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#enumValue}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#enumValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterEnumValue(@NotNull GraphqlParser.EnumValueContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#enumValue}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#enumValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitEnumValue(@NotNull GraphqlParser.EnumValueContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#arrayValue}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arrayValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterArrayValue(@NotNull GraphqlParser.ArrayValueContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#arrayValue}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arrayValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitArrayValue(@NotNull GraphqlParser.ArrayValueContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#arrayValueWithVariable}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arrayValueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterArrayValueWithVariable(@NotNull GraphqlParser.ArrayValueWithVariableContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#arrayValueWithVariable}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arrayValueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitArrayValueWithVariable(@NotNull GraphqlParser.ArrayValueWithVariableContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#objectValue}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterObjectValue(@NotNull GraphqlParser.ObjectValueContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#objectValue}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectValue}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitObjectValue(@NotNull GraphqlParser.ObjectValueContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#objectValueWithVariable}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectValueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterObjectValueWithVariable(@NotNull GraphqlParser.ObjectValueWithVariableContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#objectValueWithVariable}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectValueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitObjectValueWithVariable(@NotNull GraphqlParser.ObjectValueWithVariableContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#objectField}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectField}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterObjectField(@NotNull GraphqlParser.ObjectFieldContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#objectField}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectField}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitObjectField(@NotNull GraphqlParser.ObjectFieldContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#objectFieldWithVariable}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectFieldWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterObjectFieldWithVariable(@NotNull GraphqlParser.ObjectFieldWithVariableContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#objectFieldWithVariable}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectFieldWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitObjectFieldWithVariable(@NotNull GraphqlParser.ObjectFieldWithVariableContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#directives}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#directives}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterDirectives(@NotNull GraphqlParser.DirectivesContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#directives}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#directives}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitDirectives(@NotNull GraphqlParser.DirectivesContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#directive}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#directive}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterDirective(@NotNull GraphqlParser.DirectiveContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#directive}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#directive}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitDirective(@NotNull GraphqlParser.DirectiveContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#type}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#type}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterType(@NotNull GraphqlParser.TypeContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#type}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#type}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitType(@NotNull GraphqlParser.TypeContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#typeName}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#typeName}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterTypeName(@NotNull GraphqlParser.TypeNameContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#typeName}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#typeName}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitTypeName(@NotNull GraphqlParser.TypeNameContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#listType}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#listType}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterListType(@NotNull GraphqlParser.ListTypeContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#listType}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#listType}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitListType(@NotNull GraphqlParser.ListTypeContext ctx);
 	/**
-	 * Enter a parse tree produced by {@link GraphqlParser#nonNullType}.
+	 * Enter a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#nonNullType}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void enterNonNullType(@NotNull GraphqlParser.NonNullTypeContext ctx);
 	/**
-	 * Exit a parse tree produced by {@link GraphqlParser#nonNullType}.
+	 * Exit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#nonNullType}.
+	 *
 	 * @param ctx the parse tree
 	 */
 	void exitNonNullType(@NotNull GraphqlParser.NonNullTypeContext ctx);

--- a/src/main/java/graphql/parser/antlr/GraphqlParser.java
+++ b/src/main/java/graphql/parser/antlr/GraphqlParser.java
@@ -12,29 +12,99 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.List;
 
+/**
+ * <p>GraphqlParser class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast"})
 public class GraphqlParser extends Parser {
 	static { RuntimeMetaData.checkVersion("4.5.1", RuntimeMetaData.VERSION); }
 
+	/** Constant <code>_decisionToDFA</code> */
 	protected static final DFA[] _decisionToDFA;
+	/** Constant <code>_sharedContextCache</code> */
 	protected static final PredictionContextCache _sharedContextCache =
 		new PredictionContextCache();
+	/** Constant <code>T__0=1</code> */
 	public static final int
+		/** Constant <code>T__1=2</code> */
+		/** Constant <code>T__2=3</code> */
+		/** Constant <code>T__3=4</code> */
+		/** Constant <code>T__4=5</code> */
+		/** Constant <code>T__5=6</code> */
+		/** Constant <code>T__6=7</code> */
+		/** Constant <code>T__7=8</code> */
+		/** Constant <code>T__8=9</code> */
 		T__0=1, T__1=2, T__2=3, T__3=4, T__4=5, T__5=6, T__6=7, T__7=8, T__8=9, 
+		/** Constant <code>T__9=10</code> */
+		/** Constant <code>T__10=11</code> */
+		/** Constant <code>T__11=12</code> */
+		/** Constant <code>T__12=13</code> */
+		/** Constant <code>T__13=14</code> */
+		/** Constant <code>T__14=15</code> */
+		/** Constant <code>T__15=16</code> */
+		/** Constant <code>BooleanValue=17</code> */
 		T__9=10, T__10=11, T__11=12, T__12=13, T__13=14, T__14=15, T__15=16, BooleanValue=17, 
+		/** Constant <code>NAME=18</code> */
+		/** Constant <code>IntValue=19</code> */
+		/** Constant <code>FloatValue=20</code> */
+		/** Constant <code>Sign=21</code> */
+		/** Constant <code>IntegerPart=22</code> */
+		/** Constant <code>NonZeroDigit=23</code> */
 		NAME=18, IntValue=19, FloatValue=20, Sign=21, IntegerPart=22, NonZeroDigit=23, 
+		/** Constant <code>ExponentPart=24</code> */
+		/** Constant <code>Digit=25</code> */
+		/** Constant <code>StringValue=26</code> */
+		/** Constant <code>Ignored=27</code> */
 		ExponentPart=24, Digit=25, StringValue=26, Ignored=27;
+	/** Constant <code>RULE_document=0</code> */
 	public static final int
+		/** Constant <code>RULE_definition=1</code> */
+		/** Constant <code>RULE_operationDefinition=2</code> */
 		RULE_document = 0, RULE_definition = 1, RULE_operationDefinition = 2, 
+		/** Constant <code>RULE_operationType=3</code> */
+		/** Constant <code>RULE_variableDefinitions=4</code> */
+		/** Constant <code>RULE_variableDefinition=5</code> */
 		RULE_operationType = 3, RULE_variableDefinitions = 4, RULE_variableDefinition = 5, 
+		/** Constant <code>RULE_variable=6</code> */
+		/** Constant <code>RULE_defaultValue=7</code> */
+		/** Constant <code>RULE_selectionSet=8</code> */
+		/** Constant <code>RULE_selection=9</code> */
 		RULE_variable = 6, RULE_defaultValue = 7, RULE_selectionSet = 8, RULE_selection = 9, 
+		/** Constant <code>RULE_field=10</code> */
+		/** Constant <code>RULE_alias=11</code> */
+		/** Constant <code>RULE_arguments=12</code> */
+		/** Constant <code>RULE_argument=13</code> */
 		RULE_field = 10, RULE_alias = 11, RULE_arguments = 12, RULE_argument = 13, 
+		/** Constant <code>RULE_fragmentSpread=14</code> */
+		/** Constant <code>RULE_inlineFragment=15</code> */
+		/** Constant <code>RULE_fragmentDefinition=16</code> */
 		RULE_fragmentSpread = 14, RULE_inlineFragment = 15, RULE_fragmentDefinition = 16, 
+		/** Constant <code>RULE_fragmentName=17</code> */
+		/** Constant <code>RULE_typeCondition=18</code> */
+		/** Constant <code>RULE_value=19</code> */
+		/** Constant <code>RULE_valueWithVariable=20</code> */
 		RULE_fragmentName = 17, RULE_typeCondition = 18, RULE_value = 19, RULE_valueWithVariable = 20, 
+		/** Constant <code>RULE_enumValue=21</code> */
+		/** Constant <code>RULE_arrayValue=22</code> */
+		/** Constant <code>RULE_arrayValueWithVariable=23</code> */
 		RULE_enumValue = 21, RULE_arrayValue = 22, RULE_arrayValueWithVariable = 23, 
+		/** Constant <code>RULE_objectValue=24</code> */
+		/** Constant <code>RULE_objectValueWithVariable=25</code> */
+		/** Constant <code>RULE_objectField=26</code> */
 		RULE_objectValue = 24, RULE_objectValueWithVariable = 25, RULE_objectField = 26, 
+		/** Constant <code>RULE_objectFieldWithVariable=27</code> */
+		/** Constant <code>RULE_directives=28</code> */
+		/** Constant <code>RULE_directive=29</code> */
 		RULE_objectFieldWithVariable = 27, RULE_directives = 28, RULE_directive = 29, 
+		/** Constant <code>RULE_type=30</code> */
+		/** Constant <code>RULE_typeName=31</code> */
+		/** Constant <code>RULE_listType=32</code> */
+		/** Constant <code>RULE_nonNullType=33</code> */
 		RULE_type = 30, RULE_typeName = 31, RULE_listType = 32, RULE_nonNullType = 33;
+	/** Constant <code>ruleNames="{document, definition, operationDefinit"{trunked}</code> */
 	public static final String[] ruleNames = {
 		"document", "definition", "operationDefinition", "operationType", "variableDefinitions", 
 		"variableDefinition", "variable", "defaultValue", "selectionSet", "selection", 
@@ -56,6 +126,7 @@ public class GraphqlParser extends Parser {
 		"Sign", "IntegerPart", "NonZeroDigit", "ExponentPart", "Digit", "StringValue", 
 		"Ignored"
 	};
+	/** Constant <code>VOCABULARY</code> */
 	public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
 	/**
@@ -77,30 +148,41 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/** {@inheritDoc} */
 	@Override
 	@Deprecated
 	public String[] getTokenNames() {
 		return tokenNames;
 	}
 
+	/** {@inheritDoc} */
 	@Override
 
 	public Vocabulary getVocabulary() {
 		return VOCABULARY;
 	}
 
+	/** {@inheritDoc} */
 	@Override
 	public String getGrammarFileName() { return "Graphql.g4"; }
 
+	/** {@inheritDoc} */
 	@Override
 	public String[] getRuleNames() { return ruleNames; }
 
+	/** {@inheritDoc} */
 	@Override
 	public String getSerializedATN() { return _serializedATN; }
 
+	/** {@inheritDoc} */
 	@Override
 	public ATN getATN() { return _ATN; }
 
+	/**
+	 * <p>Constructor for GraphqlParser.</p>
+	 *
+	 * @param input a {@link org.antlr.v4.runtime.TokenStream} object.
+	 */
 	public GraphqlParser(TokenStream input) {
 		super(input);
 		_interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
@@ -123,6 +205,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>document.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.DocumentContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final DocumentContext document() throws RecognitionException {
 		DocumentContext _localctx = new DocumentContext(_ctx, getState());
 		enterRule(_localctx, 0, RULE_document);
@@ -175,6 +263,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>definition.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.DefinitionContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final DefinitionContext definition() throws RecognitionException {
 		DefinitionContext _localctx = new DefinitionContext(_ctx, getState());
 		enterRule(_localctx, 2, RULE_definition);
@@ -237,6 +331,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>operationDefinition.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.OperationDefinitionContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final OperationDefinitionContext operationDefinition() throws RecognitionException {
 		OperationDefinitionContext _localctx = new OperationDefinitionContext(_ctx, getState());
 		enterRule(_localctx, 4, RULE_operationDefinition);
@@ -315,6 +415,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>operationType.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.OperationTypeContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final OperationTypeContext operationType() throws RecognitionException {
 		OperationTypeContext _localctx = new OperationTypeContext(_ctx, getState());
 		enterRule(_localctx, 6, RULE_operationType);
@@ -360,6 +466,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>variableDefinitions.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.VariableDefinitionsContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final VariableDefinitionsContext variableDefinitions() throws RecognitionException {
 		VariableDefinitionsContext _localctx = new VariableDefinitionsContext(_ctx, getState());
 		enterRule(_localctx, 8, RULE_variableDefinitions);
@@ -419,6 +531,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>variableDefinition.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.VariableDefinitionContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final VariableDefinitionContext variableDefinition() throws RecognitionException {
 		VariableDefinitionContext _localctx = new VariableDefinitionContext(_ctx, getState());
 		enterRule(_localctx, 10, RULE_variableDefinition);
@@ -467,6 +585,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>variable.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.VariableContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final VariableContext variable() throws RecognitionException {
 		VariableContext _localctx = new VariableContext(_ctx, getState());
 		enterRule(_localctx, 12, RULE_variable);
@@ -505,6 +629,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>defaultValue.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.DefaultValueContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final DefaultValueContext defaultValue() throws RecognitionException {
 		DefaultValueContext _localctx = new DefaultValueContext(_ctx, getState());
 		enterRule(_localctx, 14, RULE_defaultValue);
@@ -546,6 +676,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>selectionSet.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.SelectionSetContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final SelectionSetContext selectionSet() throws RecognitionException {
 		SelectionSetContext _localctx = new SelectionSetContext(_ctx, getState());
 		enterRule(_localctx, 16, RULE_selectionSet);
@@ -605,6 +741,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>selection.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.SelectionContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final SelectionContext selection() throws RecognitionException {
 		SelectionContext _localctx = new SelectionContext(_ctx, getState());
 		enterRule(_localctx, 18, RULE_selection);
@@ -670,6 +812,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>field.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.FieldContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final FieldContext field() throws RecognitionException {
 		FieldContext _localctx = new FieldContext(_ctx, getState());
 		enterRule(_localctx, 20, RULE_field);
@@ -741,6 +889,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>alias.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.AliasContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final AliasContext alias() throws RecognitionException {
 		AliasContext _localctx = new AliasContext(_ctx, getState());
 		enterRule(_localctx, 22, RULE_alias);
@@ -782,6 +936,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>arguments.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ArgumentsContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ArgumentsContext arguments() throws RecognitionException {
 		ArgumentsContext _localctx = new ArgumentsContext(_ctx, getState());
 		enterRule(_localctx, 24, RULE_arguments);
@@ -836,6 +996,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>argument.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ArgumentContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ArgumentContext argument() throws RecognitionException {
 		ArgumentContext _localctx = new ArgumentContext(_ctx, getState());
 		enterRule(_localctx, 26, RULE_argument);
@@ -879,6 +1045,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>fragmentSpread.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.FragmentSpreadContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final FragmentSpreadContext fragmentSpread() throws RecognitionException {
 		FragmentSpreadContext _localctx = new FragmentSpreadContext(_ctx, getState());
 		enterRule(_localctx, 28, RULE_fragmentSpread);
@@ -933,6 +1105,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>inlineFragment.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.InlineFragmentContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final InlineFragmentContext inlineFragment() throws RecognitionException {
 		InlineFragmentContext _localctx = new InlineFragmentContext(_ctx, getState());
 		enterRule(_localctx, 30, RULE_inlineFragment);
@@ -994,6 +1172,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>fragmentDefinition.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.FragmentDefinitionContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final FragmentDefinitionContext fragmentDefinition() throws RecognitionException {
 		FragmentDefinitionContext _localctx = new FragmentDefinitionContext(_ctx, getState());
 		enterRule(_localctx, 32, RULE_fragmentDefinition);
@@ -1046,6 +1230,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>fragmentName.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.FragmentNameContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final FragmentNameContext fragmentName() throws RecognitionException {
 		FragmentNameContext _localctx = new FragmentNameContext(_ctx, getState());
 		enterRule(_localctx, 34, RULE_fragmentName);
@@ -1082,6 +1272,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>typeCondition.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.TypeConditionContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final TypeConditionContext typeCondition() throws RecognitionException {
 		TypeConditionContext _localctx = new TypeConditionContext(_ctx, getState());
 		enterRule(_localctx, 36, RULE_typeCondition);
@@ -1128,6 +1324,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>value.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ValueContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ValueContext value() throws RecognitionException {
 		ValueContext _localctx = new ValueContext(_ctx, getState());
 		enterRule(_localctx, 38, RULE_value);
@@ -1226,6 +1428,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>valueWithVariable.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ValueWithVariableContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ValueWithVariableContext valueWithVariable() throws RecognitionException {
 		ValueWithVariableContext _localctx = new ValueWithVariableContext(_ctx, getState());
 		enterRule(_localctx, 40, RULE_valueWithVariable);
@@ -1316,6 +1524,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>enumValue.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.EnumValueContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final EnumValueContext enumValue() throws RecognitionException {
 		EnumValueContext _localctx = new EnumValueContext(_ctx, getState());
 		enterRule(_localctx, 42, RULE_enumValue);
@@ -1355,6 +1569,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>arrayValue.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ArrayValueContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ArrayValueContext arrayValue() throws RecognitionException {
 		ArrayValueContext _localctx = new ArrayValueContext(_ctx, getState());
 		enterRule(_localctx, 44, RULE_arrayValue);
@@ -1411,6 +1631,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>arrayValueWithVariable.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ArrayValueWithVariableContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ArrayValueWithVariableContext arrayValueWithVariable() throws RecognitionException {
 		ArrayValueWithVariableContext _localctx = new ArrayValueWithVariableContext(_ctx, getState());
 		enterRule(_localctx, 46, RULE_arrayValueWithVariable);
@@ -1467,6 +1693,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>objectValue.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ObjectValueContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ObjectValueContext objectValue() throws RecognitionException {
 		ObjectValueContext _localctx = new ObjectValueContext(_ctx, getState());
 		enterRule(_localctx, 48, RULE_objectValue);
@@ -1523,6 +1755,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>objectValueWithVariable.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ObjectValueWithVariableContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ObjectValueWithVariableContext objectValueWithVariable() throws RecognitionException {
 		ObjectValueWithVariableContext _localctx = new ObjectValueWithVariableContext(_ctx, getState());
 		enterRule(_localctx, 50, RULE_objectValueWithVariable);
@@ -1577,6 +1815,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>objectField.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ObjectFieldContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ObjectFieldContext objectField() throws RecognitionException {
 		ObjectFieldContext _localctx = new ObjectFieldContext(_ctx, getState());
 		enterRule(_localctx, 52, RULE_objectField);
@@ -1618,6 +1862,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>objectFieldWithVariable.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ObjectFieldWithVariableContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ObjectFieldWithVariableContext objectFieldWithVariable() throws RecognitionException {
 		ObjectFieldWithVariableContext _localctx = new ObjectFieldWithVariableContext(_ctx, getState());
 		enterRule(_localctx, 54, RULE_objectFieldWithVariable);
@@ -1661,6 +1911,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>directives.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.DirectivesContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final DirectivesContext directives() throws RecognitionException {
 		DirectivesContext _localctx = new DirectivesContext(_ctx, getState());
 		enterRule(_localctx, 56, RULE_directives);
@@ -1711,6 +1967,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>directive.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.DirectiveContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final DirectiveContext directive() throws RecognitionException {
 		DirectiveContext _localctx = new DirectiveContext(_ctx, getState());
 		enterRule(_localctx, 58, RULE_directive);
@@ -1765,6 +2027,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>type.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.TypeContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final TypeContext type() throws RecognitionException {
 		TypeContext _localctx = new TypeContext(_ctx, getState());
 		enterRule(_localctx, 60, RULE_type);
@@ -1818,6 +2086,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>typeName.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.TypeNameContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final TypeNameContext typeName() throws RecognitionException {
 		TypeNameContext _localctx = new TypeNameContext(_ctx, getState());
 		enterRule(_localctx, 62, RULE_typeName);
@@ -1854,6 +2128,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>listType.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.ListTypeContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final ListTypeContext listType() throws RecognitionException {
 		ListTypeContext _localctx = new ListTypeContext(_ctx, getState());
 		enterRule(_localctx, 64, RULE_listType);
@@ -1897,6 +2177,12 @@ public class GraphqlParser extends Parser {
 		}
 	}
 
+	/**
+	 * <p>nonNullType.</p>
+	 *
+	 * @return a {@link graphql.parser.antlr.GraphqlParser.NonNullTypeContext} object.
+	 * @throws org.antlr.v4.runtime.RecognitionException if any.
+	 */
 	public final NonNullTypeContext nonNullType() throws RecognitionException {
 		NonNullTypeContext _localctx = new NonNullTypeContext(_ctx, getState());
 		enterRule(_localctx, 66, RULE_nonNullType);
@@ -1936,6 +2222,7 @@ public class GraphqlParser extends Parser {
 		return _localctx;
 	}
 
+	/** Constant <code>_serializedATN="\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\"{trunked}</code> */
 	public static final String _serializedATN =
 		"\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3\35\u0116\4\2\t\2"+
 		"\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13"+
@@ -2029,6 +2316,7 @@ public class GraphqlParser extends Parser {
 		"\u0110\3\2\2\2\u0114E\3\2\2\2\36IMRUX\\dlx\177\u0082\u0086\u0089\u008c"+
 		"\u0095\u00a0\u00a6\u00af\u00be\u00c8\u00d0\u00d9\u00e2\u00eb\u00fb\u0100"+
 		"\u0105\u0113";
+	/** Constant <code>_ATN</code> */
 	public static final ATN _ATN =
 		new ATNDeserializer().deserialize(_serializedATN.toCharArray());
 	static {

--- a/src/main/java/graphql/parser/antlr/GraphqlVisitor.java
+++ b/src/main/java/graphql/parser/antlr/GraphqlVisitor.java
@@ -4,212 +4,248 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 
 /**
  * This interface defines a complete generic visitor for a parse tree produced
- * by {@link GraphqlParser}.
+ * by {@link graphql.parser.antlr.GraphqlParser}.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
+ * @param <T> The return type of the visit operation. Use {@link java.lang.Void} for
  * operations with no return type.
+ * @author Andreas Marek
+ * @version v1.0
  */
 public interface GraphqlVisitor<T> extends ParseTreeVisitor<T> {
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#document}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#document}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitDocument(GraphqlParser.DocumentContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#definition}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#definition}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitDefinition(GraphqlParser.DefinitionContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#operationDefinition}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#operationDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitOperationDefinition(GraphqlParser.OperationDefinitionContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#operationType}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#operationType}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitOperationType(GraphqlParser.OperationTypeContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#variableDefinitions}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variableDefinitions}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitVariableDefinitions(GraphqlParser.VariableDefinitionsContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#variableDefinition}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variableDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitVariableDefinition(GraphqlParser.VariableDefinitionContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#variable}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#variable}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitVariable(GraphqlParser.VariableContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#defaultValue}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#defaultValue}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitDefaultValue(GraphqlParser.DefaultValueContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#selectionSet}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#selectionSet}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitSelectionSet(GraphqlParser.SelectionSetContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#selection}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#selection}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitSelection(GraphqlParser.SelectionContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#field}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#field}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitField(GraphqlParser.FieldContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#alias}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#alias}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitAlias(GraphqlParser.AliasContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#arguments}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arguments}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitArguments(GraphqlParser.ArgumentsContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#argument}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#argument}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitArgument(GraphqlParser.ArgumentContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#fragmentSpread}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentSpread}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitFragmentSpread(GraphqlParser.FragmentSpreadContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#inlineFragment}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#inlineFragment}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitInlineFragment(GraphqlParser.InlineFragmentContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#fragmentDefinition}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentDefinition}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitFragmentDefinition(GraphqlParser.FragmentDefinitionContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#fragmentName}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#fragmentName}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitFragmentName(GraphqlParser.FragmentNameContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#typeCondition}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#typeCondition}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitTypeCondition(GraphqlParser.TypeConditionContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#value}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#value}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitValue(GraphqlParser.ValueContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#valueWithVariable}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#valueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitValueWithVariable(GraphqlParser.ValueWithVariableContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#enumValue}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#enumValue}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitEnumValue(GraphqlParser.EnumValueContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#arrayValue}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arrayValue}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitArrayValue(GraphqlParser.ArrayValueContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#arrayValueWithVariable}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#arrayValueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitArrayValueWithVariable(GraphqlParser.ArrayValueWithVariableContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#objectValue}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectValue}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitObjectValue(GraphqlParser.ObjectValueContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#objectValueWithVariable}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectValueWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitObjectValueWithVariable(GraphqlParser.ObjectValueWithVariableContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#objectField}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectField}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitObjectField(GraphqlParser.ObjectFieldContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#objectFieldWithVariable}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#objectFieldWithVariable}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitObjectFieldWithVariable(GraphqlParser.ObjectFieldWithVariableContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#directives}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#directives}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitDirectives(GraphqlParser.DirectivesContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#directive}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#directive}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitDirective(GraphqlParser.DirectiveContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#type}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#type}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitType(GraphqlParser.TypeContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#typeName}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#typeName}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitTypeName(GraphqlParser.TypeNameContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#listType}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#listType}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */
 	T visitListType(GraphqlParser.ListTypeContext ctx);
 	/**
-	 * Visit a parse tree produced by {@link GraphqlParser#nonNullType}.
+	 * Visit a parse tree produced by {@link graphql.parser.antlr.GraphqlParser#nonNullType}.
+	 *
 	 * @param ctx the parse tree
 	 * @return the visitor result
 	 */

--- a/src/main/java/graphql/relay/Base64.java
+++ b/src/main/java/graphql/relay/Base64.java
@@ -4,8 +4,20 @@ import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
 
 
+/**
+ * <p>Base64 class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class Base64 {
 
+    /**
+     * <p>toBase64.</p>
+     *
+     * @param string a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     public static String toBase64(String string) {
         try {
             return DatatypeConverter.printBase64Binary(string.getBytes("utf-8"));
@@ -14,6 +26,12 @@ public class Base64 {
         }
     }
 
+    /**
+     * <p>fromBase64.</p>
+     *
+     * @param string a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     public static String fromBase64(String string) {
         return new String(DatatypeConverter.parseBase64Binary(string));
     }

--- a/src/main/java/graphql/relay/Connection.java
+++ b/src/main/java/graphql/relay/Connection.java
@@ -4,23 +4,49 @@ package graphql.relay;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>Connection class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class Connection {
     private List<Edge> edges =  new ArrayList<>();
 
     private PageInfo pageInfo;
 
+    /**
+     * <p>Getter for the field <code>edges</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Edge> getEdges() {
         return edges;
     }
 
+    /**
+     * <p>Setter for the field <code>edges</code>.</p>
+     *
+     * @param edges a {@link java.util.List} object.
+     */
     public void setEdges(List<Edge> edges) {
         this.edges = edges;
     }
 
+    /**
+     * <p>Getter for the field <code>pageInfo</code>.</p>
+     *
+     * @return a {@link graphql.relay.PageInfo} object.
+     */
     public PageInfo getPageInfo() {
         return pageInfo;
     }
 
+    /**
+     * <p>Setter for the field <code>pageInfo</code>.</p>
+     *
+     * @param pageInfo a {@link graphql.relay.PageInfo} object.
+     */
     public void setPageInfo(PageInfo pageInfo) {
         this.pageInfo = pageInfo;
     }

--- a/src/main/java/graphql/relay/ConnectionCursor.java
+++ b/src/main/java/graphql/relay/ConnectionCursor.java
@@ -1,18 +1,35 @@
 package graphql.relay;
 
 
+/**
+ * <p>ConnectionCursor class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class ConnectionCursor {
 
     private final String value;
 
+    /**
+     * <p>Constructor for ConnectionCursor.</p>
+     *
+     * @param value a {@link java.lang.String} object.
+     */
     public ConnectionCursor(String value) {
         this.value = value;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getValue() {
         return value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
 
@@ -27,11 +44,13 @@ public class ConnectionCursor {
         return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return value != null ? value.hashCode() : 0;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return value;

--- a/src/main/java/graphql/relay/Edge.java
+++ b/src/main/java/graphql/relay/Edge.java
@@ -1,8 +1,20 @@
 package graphql.relay;
 
 
+/**
+ * <p>Edge class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class Edge {
 
+    /**
+     * <p>Constructor for Edge.</p>
+     *
+     * @param node a {@link java.lang.Object} object.
+     * @param cursor a {@link graphql.relay.ConnectionCursor} object.
+     */
     public Edge(Object node, ConnectionCursor cursor) {
         this.node = node;
         this.cursor = cursor;
@@ -11,18 +23,38 @@ public class Edge {
     Object node;
     ConnectionCursor cursor;
 
+    /**
+     * <p>Getter for the field <code>node</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getNode() {
         return node;
     }
 
+    /**
+     * <p>Setter for the field <code>node</code>.</p>
+     *
+     * @param node a {@link java.lang.Object} object.
+     */
     public void setNode(Object node) {
         this.node = node;
     }
 
+    /**
+     * <p>Getter for the field <code>cursor</code>.</p>
+     *
+     * @return a {@link graphql.relay.ConnectionCursor} object.
+     */
     public ConnectionCursor getCursor() {
         return cursor;
     }
 
+    /**
+     * <p>Setter for the field <code>cursor</code>.</p>
+     *
+     * @param cursor a {@link graphql.relay.ConnectionCursor} object.
+     */
     public void setCursor(ConnectionCursor cursor) {
         this.cursor = cursor;
     }

--- a/src/main/java/graphql/relay/PageInfo.java
+++ b/src/main/java/graphql/relay/PageInfo.java
@@ -1,40 +1,86 @@
 package graphql.relay;
 
 
+/**
+ * <p>PageInfo class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class PageInfo {
     private ConnectionCursor startCursor;
     private ConnectionCursor endCursor;
     private  boolean hasPreviousPage;
     private  boolean hasNextPage;
 
+    /**
+     * <p>Getter for the field <code>startCursor</code>.</p>
+     *
+     * @return a {@link graphql.relay.ConnectionCursor} object.
+     */
     public ConnectionCursor getStartCursor() {
         return startCursor;
     }
 
+    /**
+     * <p>Setter for the field <code>startCursor</code>.</p>
+     *
+     * @param startCursor a {@link graphql.relay.ConnectionCursor} object.
+     */
     public void setStartCursor(ConnectionCursor startCursor) {
         this.startCursor = startCursor;
     }
 
+    /**
+     * <p>Getter for the field <code>endCursor</code>.</p>
+     *
+     * @return a {@link graphql.relay.ConnectionCursor} object.
+     */
     public ConnectionCursor getEndCursor() {
         return endCursor;
     }
 
+    /**
+     * <p>Setter for the field <code>endCursor</code>.</p>
+     *
+     * @param endCursor a {@link graphql.relay.ConnectionCursor} object.
+     */
     public void setEndCursor(ConnectionCursor endCursor) {
         this.endCursor = endCursor;
     }
 
+    /**
+     * <p>isHasPreviousPage.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isHasPreviousPage() {
         return hasPreviousPage;
     }
 
+    /**
+     * <p>Setter for the field <code>hasPreviousPage</code>.</p>
+     *
+     * @param hasPreviousPage a boolean.
+     */
     public void setHasPreviousPage(boolean hasPreviousPage) {
         this.hasPreviousPage = hasPreviousPage;
     }
 
+    /**
+     * <p>isHasNextPage.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isHasNextPage() {
         return hasNextPage;
     }
 
+    /**
+     * <p>Setter for the field <code>hasNextPage</code>.</p>
+     *
+     * @param hasNextPage a boolean.
+     */
     public void setHasNextPage(boolean hasNextPage) {
         this.hasNextPage = hasNextPage;
     }

--- a/src/main/java/graphql/relay/Relay.java
+++ b/src/main/java/graphql/relay/Relay.java
@@ -14,8 +14,15 @@ import static graphql.schema.GraphQLInputObjectType.newInputObject;
 import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLObjectType.newObject;
 
+/**
+ * <p>Relay class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class Relay {
 
+    /** Constant <code>NODE="Node"</code> */
     public static final String NODE = "Node";
     private GraphQLObjectType pageInfoType = newObject()
             .name("PageInfo")
@@ -42,6 +49,12 @@ public class Relay {
                     .build())
             .build();
 
+    /**
+     * <p>nodeInterface.</p>
+     *
+     * @param typeResolver a {@link graphql.schema.TypeResolver} object.
+     * @return a {@link graphql.schema.GraphQLInterfaceType} object.
+     */
     public GraphQLInterfaceType nodeInterface(TypeResolver typeResolver) {
         GraphQLInterfaceType node = newInterface()
                 .name(NODE)
@@ -55,6 +68,13 @@ public class Relay {
         return node;
     }
 
+    /**
+     * <p>nodeField.</p>
+     *
+     * @param nodeInterface a {@link graphql.schema.GraphQLInterfaceType} object.
+     * @param nodeDataFetcher a {@link graphql.schema.DataFetcher} object.
+     * @return a {@link graphql.schema.GraphQLFieldDefinition} object.
+     */
     public GraphQLFieldDefinition nodeField(GraphQLInterfaceType nodeInterface, DataFetcher nodeDataFetcher) {
         GraphQLFieldDefinition fieldDefinition = newFieldDefinition()
                 .name("node")
@@ -70,6 +90,11 @@ public class Relay {
         return fieldDefinition;
     }
 
+    /**
+     * <p>getConnectionFieldArguments.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLArgument> getConnectionFieldArguments() {
         List<GraphQLArgument> args = new ArrayList<>();
 
@@ -92,6 +117,11 @@ public class Relay {
         return args;
     }
     
+    /**
+     * <p>getBackwardPaginationConnectionFieldArguments.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLArgument> getBackwardPaginationConnectionFieldArguments() {
         List<GraphQLArgument> args = new ArrayList<>();
 
@@ -106,6 +136,11 @@ public class Relay {
         return args;
     }
     
+    /**
+     * <p>getForwardPaginationConnectionFieldArguments.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLArgument> getForwardPaginationConnectionFieldArguments() {
         List<GraphQLArgument> args = new ArrayList<>();
 
@@ -120,6 +155,15 @@ public class Relay {
         return args;
     }
 
+    /**
+     * <p>edgeType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param nodeType a {@link graphql.schema.GraphQLOutputType} object.
+     * @param nodeInterface a {@link graphql.schema.GraphQLInterfaceType} object.
+     * @param edgeFields a {@link java.util.List} object.
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     public GraphQLObjectType edgeType(String name, GraphQLOutputType nodeType, GraphQLInterfaceType nodeInterface, List<GraphQLFieldDefinition> edgeFields) {
 
         GraphQLObjectType edgeType = newObject()
@@ -140,6 +184,14 @@ public class Relay {
         return edgeType;
     }
 
+    /**
+     * <p>connectionType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param edgeType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param connectionFields a {@link java.util.List} object.
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     public GraphQLObjectType connectionType(String name, GraphQLObjectType edgeType, List<GraphQLFieldDefinition> connectionFields) {
 
         GraphQLObjectType connectionType = newObject()
@@ -159,6 +211,16 @@ public class Relay {
     }
 
 
+    /**
+     * <p>mutationWithClientMutationId.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param fieldName a {@link java.lang.String} object.
+     * @param inputFields a {@link java.util.List} object.
+     * @param outputFields a {@link java.util.List} object.
+     * @param dataFetcher a {@link graphql.schema.DataFetcher} object.
+     * @return a {@link graphql.schema.GraphQLFieldDefinition} object.
+     */
     public GraphQLFieldDefinition mutationWithClientMutationId(String name, String fieldName,
                                                                List<GraphQLInputObjectField> inputFields,
                                                                List<GraphQLFieldDefinition> outputFields,
@@ -201,10 +263,23 @@ public class Relay {
         public String id;
     }
 
+    /**
+     * <p>toGlobalId.</p>
+     *
+     * @param type a {@link java.lang.String} object.
+     * @param id a {@link java.lang.String} object.
+     * @return a {@link java.lang.String} object.
+     */
     public String toGlobalId(String type, String id) {
         return Base64.toBase64(type + ":" + id);
     }
 
+    /**
+     * <p>fromGlobalId.</p>
+     *
+     * @param globalId a {@link java.lang.String} object.
+     * @return a {@link graphql.relay.Relay.ResolvedGlobalId} object.
+     */
     public ResolvedGlobalId fromGlobalId(String globalId) {
         String[] split = Base64.fromBase64(globalId).split(":", 2);
         return new ResolvedGlobalId(split[0], split[1]);

--- a/src/main/java/graphql/relay/SimpleListConnection.java
+++ b/src/main/java/graphql/relay/SimpleListConnection.java
@@ -7,12 +7,23 @@ import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>SimpleListConnection class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class SimpleListConnection implements DataFetcher {
 
     private static final String DUMMY_CURSOR_PREFIX = "simple-cursor";
     private List<?> data = new ArrayList<>();
 
 
+    /**
+     * <p>Constructor for SimpleListConnection.</p>
+     *
+     * @param data a {@link java.util.List} object.
+     */
     public SimpleListConnection(List<?> data) {
         this.data = data;
 
@@ -28,6 +39,7 @@ public class SimpleListConnection implements DataFetcher {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public Object get(DataFetchingEnvironment environment) {
 
@@ -85,6 +97,12 @@ public class SimpleListConnection implements DataFetcher {
     }
 
 
+    /**
+     * <p>cursorForObjectInConnection.</p>
+     *
+     * @param object a {@link java.lang.Object} object.
+     * @return a {@link graphql.relay.ConnectionCursor} object.
+     */
     public ConnectionCursor cursorForObjectInConnection(Object object) {
         int index = data.indexOf(object);
         String cursor = createCursor(index);

--- a/src/main/java/graphql/schema/Coercing.java
+++ b/src/main/java/graphql/schema/Coercing.java
@@ -1,6 +1,12 @@
 package graphql.schema;
 
 
+/**
+ * <p>Coercing interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface Coercing {
 
 
@@ -23,6 +29,7 @@ public interface Coercing {
 
     /**
      * Called to convert a AST node
+     *
      * @param input is never null
      * @return null if not possible/invalid
      */

--- a/src/main/java/graphql/schema/DataFetcher.java
+++ b/src/main/java/graphql/schema/DataFetcher.java
@@ -1,7 +1,19 @@
 package graphql.schema;
 
 
+/**
+ * <p>DataFetcher interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface DataFetcher {
 
+    /**
+     * <p>get.</p>
+     *
+     * @param environment a {@link graphql.schema.DataFetchingEnvironment} object.
+     * @return a {@link java.lang.Object} object.
+     */
     Object get(DataFetchingEnvironment environment);
 }

--- a/src/main/java/graphql/schema/DataFetchingEnvironment.java
+++ b/src/main/java/graphql/schema/DataFetchingEnvironment.java
@@ -6,6 +6,12 @@ import graphql.language.Field;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>DataFetchingEnvironment class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class DataFetchingEnvironment {
     private final Object source;
     private final Map<String, Object> arguments;
@@ -15,6 +21,17 @@ public class DataFetchingEnvironment {
     private final GraphQLType parentType;
     private final GraphQLSchema graphQLSchema;
 
+    /**
+     * <p>Constructor for DataFetchingEnvironment.</p>
+     *
+     * @param source a {@link java.lang.Object} object.
+     * @param arguments a {@link java.util.Map} object.
+     * @param context a {@link java.lang.Object} object.
+     * @param fields a {@link java.util.List} object.
+     * @param fieldType a {@link graphql.schema.GraphQLOutputType} object.
+     * @param parentType a {@link graphql.schema.GraphQLType} object.
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     */
     public DataFetchingEnvironment(Object source, Map<String, Object> arguments, Object context, List<Field> fields, GraphQLOutputType fieldType, GraphQLType parentType, GraphQLSchema graphQLSchema) {
         this.source = source;
         this.arguments = arguments;
@@ -25,38 +42,86 @@ public class DataFetchingEnvironment {
         this.graphQLSchema = graphQLSchema;
     }
 
+    /**
+     * <p>Getter for the field <code>source</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getSource() {
         return source;
     }
 
+    /**
+     * <p>Getter for the field <code>arguments</code>.</p>
+     *
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, Object> getArguments() {
         return arguments;
     }
 
+    /**
+     * <p>containsArgument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a boolean.
+     */
     public boolean containsArgument(String name) {
         return arguments.containsKey(name);
     }
 
+    /**
+     * <p>getArgument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param <T> a T object.
+     * @return a T object.
+     */
     public <T> T getArgument(String name) {
         return (T) arguments.get(name);
     }
 
+    /**
+     * <p>Getter for the field <code>context</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getContext() {
         return context;
     }
 
+    /**
+     * <p>Getter for the field <code>fields</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<Field> getFields() {
         return fields;
     }
 
+    /**
+     * <p>Getter for the field <code>fieldType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLOutputType} object.
+     */
     public GraphQLOutputType getFieldType() {
         return fieldType;
     }
 
+    /**
+     * <p>Getter for the field <code>parentType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLType} object.
+     */
     public GraphQLType getParentType() {
         return parentType;
     }
 
+    /**
+     * <p>Getter for the field <code>graphQLSchema</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLSchema} object.
+     */
     public GraphQLSchema getGraphQLSchema() {
         return graphQLSchema;
     }

--- a/src/main/java/graphql/schema/FieldDataFetcher.java
+++ b/src/main/java/graphql/schema/FieldDataFetcher.java
@@ -10,6 +10,9 @@ import static graphql.Scalars.GraphQLBoolean;
 
 /**
  * Fetches data directly from a field.
+ *
+ * @author Andreas Marek
+ * @version v1.3
  */
 public class FieldDataFetcher implements DataFetcher {
 
@@ -20,12 +23,14 @@ public class FieldDataFetcher implements DataFetcher {
 
     /**
      * Ctor.
+     *
      * @param fieldName The name of the field.
      */
     public FieldDataFetcher(String fieldName) {
         this.fieldName = fieldName;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Object get(DataFetchingEnvironment environment) {
         Object source = environment.getSource();

--- a/src/main/java/graphql/schema/GraphQLArgument.java
+++ b/src/main/java/graphql/schema/GraphQLArgument.java
@@ -3,6 +3,12 @@ package graphql.schema;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLArgument class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLArgument {
 
     private final String name;
@@ -10,6 +16,14 @@ public class GraphQLArgument {
     private GraphQLInputType type;
     private final Object defaultValue;
 
+    /**
+     * <p>Constructor for GraphQLArgument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param type a {@link graphql.schema.GraphQLInputType} object.
+     * @param defaultValue a {@link java.lang.Object} object.
+     */
     public GraphQLArgument(String name, String description, GraphQLInputType type, Object defaultValue) {
         assertNotNull(name, "name can't be null");
         assertNotNull(type, "type can't be null");
@@ -19,28 +33,59 @@ public class GraphQLArgument {
         this.defaultValue = defaultValue;
     }
 
+    /**
+     * <p>Constructor for GraphQLArgument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param type a {@link graphql.schema.GraphQLInputType} object.
+     */
     public GraphQLArgument(String name, GraphQLInputType type) {
         this(name, null, type, null);
     }
 
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInputType} object.
+     */
     public GraphQLInputType getType() {
         return type;
     }
 
+    /**
+     * <p>Getter for the field <code>defaultValue</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getDefaultValue() {
         return defaultValue;
     }
 
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>newArgument.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLArgument.Builder} object.
+     */
     public static Builder newArgument() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLCompositeType.java
+++ b/src/main/java/graphql/schema/GraphQLCompositeType.java
@@ -1,5 +1,11 @@
 package graphql.schema;
 
 
+/**
+ * <p>GraphQLCompositeType interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLCompositeType extends GraphQLType {
 }

--- a/src/main/java/graphql/schema/GraphQLDirective.java
+++ b/src/main/java/graphql/schema/GraphQLDirective.java
@@ -6,6 +6,12 @@ import java.util.List;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLDirective class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLDirective {
 
     private final String name;
@@ -15,6 +21,16 @@ public class GraphQLDirective {
     private final boolean onFragment;
     private final boolean onField;
 
+    /**
+     * <p>Constructor for GraphQLDirective.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param arguments a {@link java.util.List} object.
+     * @param onOperation a boolean.
+     * @param onFragment a boolean.
+     * @param onField a boolean.
+     */
     public GraphQLDirective(String name, String description, List<GraphQLArgument> arguments, boolean onOperation, boolean onFragment, boolean onField) {
         assertNotNull(name, "name can't be null");
         assertNotNull(arguments, "arguments can't be null");
@@ -26,14 +42,30 @@ public class GraphQLDirective {
         this.onField = onField;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>arguments</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLArgument> getArguments() {
         return new ArrayList<>(arguments);
     }
 
+    /**
+     * <p>getArgument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.schema.GraphQLArgument} object.
+     */
     public GraphQLArgument getArgument(String name) {
         for (GraphQLArgument argument : arguments) {
             if (argument.getName().equals(name)) return argument;
@@ -41,22 +73,47 @@ public class GraphQLDirective {
         return null;
     }
 
+    /**
+     * <p>isOnOperation.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isOnOperation() {
         return onOperation;
     }
 
+    /**
+     * <p>isOnFragment.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isOnFragment() {
         return onFragment;
     }
 
+    /**
+     * <p>isOnField.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isOnField() {
         return onField;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>newDirective.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLDirective.Builder} object.
+     */
     public static Builder newDirective() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLEnumType.java
+++ b/src/main/java/graphql/schema/GraphQLEnumType.java
@@ -10,6 +10,12 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLEnumType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLUnmodifiedType {
 
     private final String name;
@@ -50,11 +56,23 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
         return null;
     }
 
+    /**
+     * <p>getValues.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLEnumValueDefinition> getValues() {
         return new ArrayList<>(valueDefinitionMap.values());
     }
 
 
+    /**
+     * <p>Constructor for GraphQLEnumType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param values a {@link java.util.List} object.
+     */
     public GraphQLEnumType(String name, String description, List<GraphQLEnumValueDefinition> values) {
         assertNotNull(name, "name can't be null");
         this.name = name;
@@ -68,19 +86,39 @@ public class GraphQLEnumType implements GraphQLType, GraphQLInputType, GraphQLOu
         }
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>Getter for the field <code>coercing</code>.</p>
+     *
+     * @return a {@link graphql.schema.Coercing} object.
+     */
     public Coercing getCoercing() {
         return coercing;
     }
 
 
+    /**
+     * <p>newEnum.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLEnumType.Builder} object.
+     */
     public static Builder newEnum() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLEnumValueDefinition.java
@@ -3,6 +3,12 @@ package graphql.schema;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLEnumValueDefinition class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLEnumValueDefinition {
 
     private final String name;
@@ -10,6 +16,14 @@ public class GraphQLEnumValueDefinition {
     private final Object value;
     private final String deprecationReason;
 
+    /**
+     * <p>Constructor for GraphQLEnumValueDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param value a {@link java.lang.Object} object.
+     * @param deprecationReason a {@link java.lang.String} object.
+     */
     public GraphQLEnumValueDefinition(String name, String description, Object value, String deprecationReason) {
         assertNotNull(name, "name can't be null");
         this.name = name;
@@ -18,26 +32,58 @@ public class GraphQLEnumValueDefinition {
         this.deprecationReason = deprecationReason;
     }
 
+    /**
+     * <p>Constructor for GraphQLEnumValueDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param value a {@link java.lang.Object} object.
+     */
     public GraphQLEnumValueDefinition(String name, String description, Object value) {
         this(name, description, value, null);
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>Getter for the field <code>value</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getValue() {
         return value;
     }
 
+    /**
+     * <p>isDeprecated.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isDeprecated() {
         return deprecationReason != null;
     }
 
+    /**
+     * <p>Getter for the field <code>deprecationReason</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDeprecationReason() {
         return deprecationReason;
     }

--- a/src/main/java/graphql/schema/GraphQLFieldDefinition.java
+++ b/src/main/java/graphql/schema/GraphQLFieldDefinition.java
@@ -7,6 +7,12 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLFieldDefinition class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLFieldDefinition {
 
     private final String name;
@@ -17,6 +23,16 @@ public class GraphQLFieldDefinition {
     private final List<GraphQLArgument> arguments = new ArrayList<>();
 
 
+    /**
+     * <p>Constructor for GraphQLFieldDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param type a {@link graphql.schema.GraphQLOutputType} object.
+     * @param dataFetcher a {@link graphql.schema.DataFetcher} object.
+     * @param arguments a {@link java.util.List} object.
+     * @param deprecationReason a {@link java.lang.String} object.
+     */
     public GraphQLFieldDefinition(String name, String description, GraphQLOutputType type, DataFetcher dataFetcher, List<GraphQLArgument> arguments, String deprecationReason) {
         assertNotNull(name, "name can't be null");
         assertNotNull(dataFetcher, "dataFetcher can't be null");
@@ -35,19 +51,40 @@ public class GraphQLFieldDefinition {
         type = (GraphQLOutputType) new SchemaUtil().resolveTypeReference(type, typeMap);
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
 
+    /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLOutputType} object.
+     */
     public GraphQLOutputType getType() {
         return type;
     }
 
+    /**
+     * <p>Getter for the field <code>dataFetcher</code>.</p>
+     *
+     * @return a {@link graphql.schema.DataFetcher} object.
+     */
     public DataFetcher getDataFetcher() {
         return dataFetcher;
     }
 
+    /**
+     * <p>getArgument.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.schema.GraphQLArgument} object.
+     */
     public GraphQLArgument getArgument(String name) {
         for (GraphQLArgument argument : arguments) {
             if (argument.getName().equals(name)) return argument;
@@ -55,22 +92,47 @@ public class GraphQLFieldDefinition {
         return null;
     }
 
+    /**
+     * <p>Getter for the field <code>arguments</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLArgument> getArguments() {
         return new ArrayList<>(arguments);
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>Getter for the field <code>deprecationReason</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDeprecationReason() {
         return deprecationReason;
     }
 
+    /**
+     * <p>isDeprecated.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isDeprecated() {
         return deprecationReason != null;
     }
 
+    /**
+     * <p>newFieldDefinition.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLFieldDefinition.Builder} object.
+     */
     public static Builder newFieldDefinition() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLFieldsContainer.java
+++ b/src/main/java/graphql/schema/GraphQLFieldsContainer.java
@@ -3,9 +3,26 @@ package graphql.schema;
 import java.util.List;
 
 
+/**
+ * <p>GraphQLFieldsContainer interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLFieldsContainer extends GraphQLType{
 
+    /**
+     * <p>getFieldDefinition.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.schema.GraphQLFieldDefinition} object.
+     */
     GraphQLFieldDefinition getFieldDefinition(String name);
 
+    /**
+     * <p>getFieldDefinitions.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     List<GraphQLFieldDefinition> getFieldDefinitions();
 }

--- a/src/main/java/graphql/schema/GraphQLInputObjectField.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectField.java
@@ -3,6 +3,12 @@ package graphql.schema;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLInputObjectField class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLInputObjectField {
 
     private final String name;
@@ -10,10 +16,24 @@ public class GraphQLInputObjectField {
     private GraphQLInputType type;
     private final Object defaultValue;
 
+    /**
+     * <p>Constructor for GraphQLInputObjectField.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param type a {@link graphql.schema.GraphQLInputType} object.
+     */
     public GraphQLInputObjectField(String name, GraphQLInputType type) {
         this(name, null, type, null);
     }
 
+    /**
+     * <p>Constructor for GraphQLInputObjectField.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param type a {@link graphql.schema.GraphQLInputType} object.
+     * @param defaultValue a {@link java.lang.Object} object.
+     */
     public GraphQLInputObjectField(String name, String description, GraphQLInputType type, Object defaultValue) {
         assertNotNull(name, "name can't be null");
         assertNotNull(type, "type can't be null");
@@ -24,22 +44,47 @@ public class GraphQLInputObjectField {
     }
 
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>type</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInputType} object.
+     */
     public GraphQLInputType getType() {
         return type;
     }
 
+    /**
+     * <p>Getter for the field <code>defaultValue</code>.</p>
+     *
+     * @return a {@link java.lang.Object} object.
+     */
     public Object getDefaultValue() {
         return defaultValue;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>newInputObjectField.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInputObjectField.Builder} object.
+     */
     public static Builder newInputObjectField() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLInputObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLInputObjectType.java
@@ -8,6 +8,12 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLInputObjectType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
@@ -16,6 +22,13 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
 
     private final Map<String, GraphQLInputObjectField> fieldMap = new LinkedHashMap<>();
 
+    /**
+     * <p>Constructor for GraphQLInputObjectType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param fields a {@link java.util.List} object.
+     */
     public GraphQLInputObjectType(String name, String description, List<GraphQLInputObjectField> fields) {
         assertNotNull(name, "name can't be null");
         assertNotNull(fields, "fields can't be null");
@@ -30,22 +43,48 @@ public class GraphQLInputObjectType implements GraphQLType, GraphQLInputType, Gr
         }
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>getFields.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLInputObjectField> getFields() {
         return new ArrayList<>(fieldMap.values());
     }
 
+    /**
+     * <p>getField.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.schema.GraphQLInputObjectField} object.
+     */
     public GraphQLInputObjectField getField(String name) {
         return fieldMap.get(name);
     }
 
+    /**
+     * <p>newInputObject.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInputObjectType.Builder} object.
+     */
     public static Builder newInputObject() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLInputType.java
+++ b/src/main/java/graphql/schema/GraphQLInputType.java
@@ -4,6 +4,9 @@ package graphql.schema;
 /**
  * All types allowed as arguments or variables. In other word
  * all Inputs types for a query/mutation.
+ *
+ * @author Andreas Marek
+ * @version v1.0
  */
 public interface GraphQLInputType extends GraphQLType {
 }

--- a/src/main/java/graphql/schema/GraphQLInterfaceType.java
+++ b/src/main/java/graphql/schema/GraphQLInterfaceType.java
@@ -8,6 +8,12 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLInterfaceType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
@@ -15,6 +21,14 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
     private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
     private final TypeResolver typeResolver;
 
+    /**
+     * <p>Constructor for GraphQLInterfaceType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param fieldDefinitions a {@link java.util.List} object.
+     * @param typeResolver a {@link graphql.schema.TypeResolver} object.
+     */
     public GraphQLInterfaceType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, TypeResolver typeResolver) {
         assertNotNull(name, "name can't null");
         assertNotNull(typeResolver, "typeResolver can't null");
@@ -31,27 +45,49 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
         }
     }
 
+    /** {@inheritDoc} */
     public GraphQLFieldDefinition getFieldDefinition(String name) {
         return fieldDefinitionsByName.get(name);
     }
 
 
+    /**
+     * <p>getFieldDefinitions.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
         return new ArrayList<>(fieldDefinitionsByName.values());
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>Getter for the field <code>typeResolver</code>.</p>
+     *
+     * @return a {@link graphql.schema.TypeResolver} object.
+     */
     public TypeResolver getTypeResolver() {
         return typeResolver;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "GraphQLInterfaceType{" +
@@ -62,6 +98,11 @@ public class GraphQLInterfaceType implements GraphQLType, GraphQLOutputType, Gra
                 '}';
     }
 
+    /**
+     * <p>newInterface.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInterfaceType.Builder} object.
+     */
     public static Builder newInterface() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLList.java
+++ b/src/main/java/graphql/schema/GraphQLList.java
@@ -5,16 +5,32 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLList class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLList implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLModifiedType, GraphQLNullableType {
 
     private GraphQLType wrappedType;
 
+    /**
+     * <p>Constructor for GraphQLList.</p>
+     *
+     * @param wrappedType a {@link graphql.schema.GraphQLType} object.
+     */
     public GraphQLList(GraphQLType wrappedType) {
         assertNotNull(wrappedType, "wrappedType can't be null");
         this.wrappedType = wrappedType;
     }
 
 
+    /**
+     * <p>Getter for the field <code>wrappedType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLType} object.
+     */
     public GraphQLType getWrappedType() {
         return wrappedType;
     }
@@ -23,6 +39,7 @@ public class GraphQLList implements GraphQLType, GraphQLInputType, GraphQLOutput
         wrappedType = new SchemaUtil().resolveTypeReference(wrappedType, typeMap);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -34,11 +51,13 @@ public class GraphQLList implements GraphQLType, GraphQLInputType, GraphQLOutput
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return wrappedType != null ? wrappedType.hashCode() : 0;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return null;

--- a/src/main/java/graphql/schema/GraphQLModifiedType.java
+++ b/src/main/java/graphql/schema/GraphQLModifiedType.java
@@ -1,7 +1,18 @@
 package graphql.schema;
 
 
+/**
+ * <p>GraphQLModifiedType interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLModifiedType extends GraphQLType {
 
+    /**
+     * <p>getWrappedType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLType} object.
+     */
     GraphQLType getWrappedType();
 }

--- a/src/main/java/graphql/schema/GraphQLNonNull.java
+++ b/src/main/java/graphql/schema/GraphQLNonNull.java
@@ -5,15 +5,31 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLNonNull class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLModifiedType {
 
     private  GraphQLType wrappedType;
 
+    /**
+     * <p>Constructor for GraphQLNonNull.</p>
+     *
+     * @param wrappedType a {@link graphql.schema.GraphQLType} object.
+     */
     public GraphQLNonNull(GraphQLType wrappedType) {
         assertNotNull(wrappedType, "wrappedType can't be null");
         this.wrappedType = wrappedType;
     }
 
+    /**
+     * <p>Getter for the field <code>wrappedType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLType} object.
+     */
     public GraphQLType getWrappedType() {
         return wrappedType;
     }
@@ -22,6 +38,7 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
         wrappedType = new SchemaUtil().resolveTypeReference(wrappedType, typeMap);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -33,11 +50,13 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
 
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return wrappedType != null ? wrappedType.hashCode() : 0;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "GraphQLNonNull{" +
@@ -45,6 +64,7 @@ public class GraphQLNonNull implements GraphQLType, GraphQLInputType, GraphQLOut
                 '}';
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return null;

--- a/src/main/java/graphql/schema/GraphQLNullableType.java
+++ b/src/main/java/graphql/schema/GraphQLNullableType.java
@@ -1,5 +1,11 @@
 package graphql.schema;
 
 
+/**
+ * <p>GraphQLNullableType interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLNullableType extends  GraphQLType{
 }

--- a/src/main/java/graphql/schema/GraphQLObjectType.java
+++ b/src/main/java/graphql/schema/GraphQLObjectType.java
@@ -8,6 +8,12 @@ import java.util.Map;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLObjectType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQLFieldsContainer, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
@@ -15,6 +21,14 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
     private final Map<String, GraphQLFieldDefinition> fieldDefinitionsByName = new LinkedHashMap<>();
     private final List<GraphQLInterfaceType> interfaces = new ArrayList<>();
 
+    /**
+     * <p>Constructor for GraphQLObjectType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param fieldDefinitions a {@link java.util.List} object.
+     * @param interfaces a {@link java.util.List} object.
+     */
     public GraphQLObjectType(String name, String description, List<GraphQLFieldDefinition> fieldDefinitions, List<GraphQLInterfaceType> interfaces) {
         assertNotNull(name, "name can't null");
         assertNotNull(fieldDefinitions, "fieldDefinitions can't null");
@@ -32,30 +46,52 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
     }
 
 
+    /** {@inheritDoc} */
     public GraphQLFieldDefinition getFieldDefinition(String name) {
         return fieldDefinitionsByName.get(name);
     }
 
 
+    /**
+     * <p>getFieldDefinitions.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLFieldDefinition> getFieldDefinitions() {
         return new ArrayList<>(fieldDefinitionsByName.values());
     }
 
 
+    /**
+     * <p>Getter for the field <code>interfaces</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLInterfaceType> getInterfaces() {
         return new ArrayList<>(interfaces);
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "GraphQLObjectType{" +
@@ -66,6 +102,11 @@ public class GraphQLObjectType implements GraphQLType, GraphQLOutputType, GraphQ
                 '}';
     }
 
+    /**
+     * <p>newObject.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLObjectType.Builder} object.
+     */
     public static Builder newObject() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLOutputType.java
+++ b/src/main/java/graphql/schema/GraphQLOutputType.java
@@ -1,5 +1,11 @@
 package graphql.schema;
 
 
+/**
+ * <p>GraphQLOutputType interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLOutputType extends GraphQLType{
 }

--- a/src/main/java/graphql/schema/GraphQLScalarType.java
+++ b/src/main/java/graphql/schema/GraphQLScalarType.java
@@ -3,6 +3,12 @@ package graphql.schema;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLScalarType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQLOutputType, GraphQLUnmodifiedType,GraphQLNullableType {
 
     private final String name;
@@ -10,6 +16,13 @@ public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQL
     private final Coercing coercing;
 
 
+    /**
+     * <p>Constructor for GraphQLScalarType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param coercing a {@link graphql.schema.Coercing} object.
+     */
     public GraphQLScalarType(String name, String description, Coercing coercing) {
         assertNotNull(name, "name can't be null");
         assertNotNull(coercing, "coercing can't be null");
@@ -18,20 +31,36 @@ public class GraphQLScalarType implements GraphQLType, GraphQLInputType, GraphQL
         this.coercing = coercing;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }
 
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
 
+    /**
+     * <p>Getter for the field <code>coercing</code>.</p>
+     *
+     * @return a {@link graphql.schema.Coercing} object.
+     */
     public Coercing getCoercing() {
         return coercing;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "GraphQLScalarType{" +

--- a/src/main/java/graphql/schema/GraphQLSchema.java
+++ b/src/main/java/graphql/schema/GraphQLSchema.java
@@ -13,6 +13,12 @@ import java.util.Set;
 import graphql.Assert;
 import graphql.Directives;
 
+/**
+ * <p>GraphQLSchema class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLSchema {
 
     private final GraphQLObjectType queryType;
@@ -20,14 +26,31 @@ public class GraphQLSchema {
     private final Map<String, GraphQLType> typeMap;
     private Set<GraphQLType> dictionary;
 
+    /**
+     * <p>Constructor for GraphQLSchema.</p>
+     *
+     * @param queryType a {@link graphql.schema.GraphQLObjectType} object.
+     */
     public GraphQLSchema(GraphQLObjectType queryType) {
         this(queryType, null, Collections.<GraphQLType>emptySet());
     }
 
+    /**
+     * <p>Getter for the field <code>dictionary</code>.</p>
+     *
+     * @return a {@link java.util.Set} object.
+     */
     public Set<GraphQLType> getDictionary() {
       return dictionary;
     }
 
+    /**
+     * <p>Constructor for GraphQLSchema.</p>
+     *
+     * @param queryType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param mutationType a {@link graphql.schema.GraphQLObjectType} object.
+     * @param dictionary a {@link java.util.Set} object.
+     */
     public GraphQLSchema(GraphQLObjectType queryType, GraphQLObjectType mutationType, Set<GraphQLType> dictionary) {
         assertNotNull(dictionary, "dictionary can't be null");
         assertNotNull(queryType, "queryType can't be null");
@@ -37,27 +60,59 @@ public class GraphQLSchema {
         typeMap = new SchemaUtil().allTypes(this, dictionary);
     }
 
+    /**
+     * <p>getType.</p>
+     *
+     * @param typeName a {@link java.lang.String} object.
+     * @return a {@link graphql.schema.GraphQLType} object.
+     */
     public GraphQLType getType(String typeName) {
         return typeMap.get(typeName);
     }
 
+    /**
+     * <p>getAllTypesAsList.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLType> getAllTypesAsList() {
         return new ArrayList<>(typeMap.values());
     }
 
+    /**
+     * <p>Getter for the field <code>queryType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     public GraphQLObjectType getQueryType() {
         return queryType;
     }
 
 
+    /**
+     * <p>Getter for the field <code>mutationType</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     public GraphQLObjectType getMutationType() {
         return mutationType;
     }
 
+    /**
+     * <p>getDirectives.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLDirective> getDirectives() {
         return Arrays.asList(Directives.IncludeDirective, Directives.SkipDirective);
     }
 
+    /**
+     * <p>getDirective.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.schema.GraphQLDirective} object.
+     */
     public GraphQLDirective getDirective(String name) {
         for (GraphQLDirective directive : getDirectives()) {
             if (directive.getName().equals(name)) return directive;
@@ -66,10 +121,20 @@ public class GraphQLSchema {
     }
 
 
+    /**
+     * <p>isSupportingMutations.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isSupportingMutations() {
         return mutationType != null;
     }
 
+    /**
+     * <p>newSchema.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLSchema.Builder} object.
+     */
     public static Builder newSchema() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLType.java
+++ b/src/main/java/graphql/schema/GraphQLType.java
@@ -1,8 +1,19 @@
 package graphql.schema;
 
 
+/**
+ * <p>GraphQLType interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLType {
 
+    /**
+     * <p>getName.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     String getName();
 
 

--- a/src/main/java/graphql/schema/GraphQLTypeReference.java
+++ b/src/main/java/graphql/schema/GraphQLTypeReference.java
@@ -6,16 +6,29 @@ import static graphql.Assert.assertNotNull;
 /**
  * A special type to allow a object/interface types to reference itself. It's replaced with the real type
  * object when the schema is build.
+ *
+ * @author Andreas Marek
+ * @version v1.0
  */
 public class GraphQLTypeReference implements GraphQLType, GraphQLOutputType {
 
     private final String name;
 
+    /**
+     * <p>Constructor for GraphQLTypeReference.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     */
     public GraphQLTypeReference(String name) {
         assertNotNull(name, "name can't be null");
         this.name = name;
     }
 
+    /**
+     * <p>Getter for the field <code>name</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getName() {
         return name;
     }

--- a/src/main/java/graphql/schema/GraphQLUnionType.java
+++ b/src/main/java/graphql/schema/GraphQLUnionType.java
@@ -6,6 +6,12 @@ import java.util.List;
 
 import static graphql.Assert.assertNotNull;
 
+/**
+ * <p>GraphQLUnionType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQLCompositeType, GraphQLUnmodifiedType, GraphQLNullableType {
 
     private final String name;
@@ -14,6 +20,14 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
     private final TypeResolver typeResolver;
 
 
+    /**
+     * <p>Constructor for GraphQLUnionType.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @param description a {@link java.lang.String} object.
+     * @param types a {@link java.util.List} object.
+     * @param typeResolver a {@link graphql.schema.TypeResolver} object.
+     */
     public GraphQLUnionType(String name, String description, List<GraphQLType> types, TypeResolver typeResolver) {
         assertNotNull(name, "name can't be null");
         assertNotNull(types, "types can't be null");
@@ -25,23 +39,44 @@ public class GraphQLUnionType implements GraphQLType, GraphQLOutputType, GraphQL
     }
 
 
+    /**
+     * <p>Getter for the field <code>types</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLType> getTypes() {
         return new ArrayList<>(types);
     }
 
+    /**
+     * <p>Getter for the field <code>typeResolver</code>.</p>
+     *
+     * @return a {@link graphql.schema.TypeResolver} object.
+     */
     public TypeResolver getTypeResolver() {
         return typeResolver;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
+    /**
+     * <p>Getter for the field <code>description</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * <p>newUnionType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLUnionType.Builder} object.
+     */
     public static Builder newUnionType() {
         return new Builder();
     }

--- a/src/main/java/graphql/schema/GraphQLUnmodifiedType.java
+++ b/src/main/java/graphql/schema/GraphQLUnmodifiedType.java
@@ -1,5 +1,11 @@
 package graphql.schema;
 
 
+/**
+ * <p>GraphQLUnmodifiedType interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface GraphQLUnmodifiedType extends GraphQLType{
 }

--- a/src/main/java/graphql/schema/PropertyDataFetcher.java
+++ b/src/main/java/graphql/schema/PropertyDataFetcher.java
@@ -7,14 +7,26 @@ import java.util.Map;
 
 import static graphql.Scalars.GraphQLBoolean;
 
+/**
+ * <p>PropertyDataFetcher class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class PropertyDataFetcher implements DataFetcher {
 
     private final String propertyName;
 
+    /**
+     * <p>Constructor for PropertyDataFetcher.</p>
+     *
+     * @param propertyName a {@link java.lang.String} object.
+     */
     public PropertyDataFetcher(String propertyName) {
         this.propertyName = propertyName;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Object get(DataFetchingEnvironment environment) {
         Object source = environment.getSource();

--- a/src/main/java/graphql/schema/SchemaUtil.java
+++ b/src/main/java/graphql/schema/SchemaUtil.java
@@ -10,8 +10,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * <p>SchemaUtil class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class SchemaUtil {
 
+    /**
+     * <p>isLeafType.</p>
+     *
+     * @param type a {@link graphql.schema.GraphQLType} object.
+     * @return a boolean.
+     */
     public boolean isLeafType(GraphQLType type) {
         GraphQLUnmodifiedType unmodifiedType = getUnmodifiedType(type);
         return
@@ -19,6 +31,12 @@ public class SchemaUtil {
                         || unmodifiedType instanceof GraphQLEnumType;
     }
 
+    /**
+     * <p>isInputType.</p>
+     *
+     * @param graphQLType a {@link graphql.schema.GraphQLType} object.
+     * @return a boolean.
+     */
     public boolean isInputType(GraphQLType graphQLType) {
         GraphQLUnmodifiedType unmodifiedType = getUnmodifiedType(graphQLType);
         return
@@ -27,6 +45,12 @@ public class SchemaUtil {
                         || unmodifiedType instanceof GraphQLInputObjectType;
     }
 
+    /**
+     * <p>getUnmodifiedType.</p>
+     *
+     * @param graphQLType a {@link graphql.schema.GraphQLType} object.
+     * @return a {@link graphql.schema.GraphQLUnmodifiedType} object.
+     */
     public GraphQLUnmodifiedType getUnmodifiedType(GraphQLType graphQLType) {
         if (graphQLType instanceof GraphQLModifiedType) {
             return getUnmodifiedType(((GraphQLModifiedType) graphQLType).getWrappedType());
@@ -105,6 +129,13 @@ public class SchemaUtil {
     }
 
 
+    /**
+     * <p>allTypes.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param dictionary a {@link java.util.Set} object.
+     * @return a {@link java.util.Map} object.
+     */
     public Map<String, GraphQLType> allTypes(GraphQLSchema schema,  Set<GraphQLType> dictionary) {
         Map<String, GraphQLType> typesByName = new LinkedHashMap<>();
         collectTypes(schema.getQueryType(), typesByName);
@@ -120,6 +151,13 @@ public class SchemaUtil {
         return typesByName;
     }
 
+    /**
+     * <p>findImplementations.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param interfaceType a {@link graphql.schema.GraphQLInterfaceType} object.
+     * @return a {@link java.util.List} object.
+     */
     public List<GraphQLObjectType> findImplementations(GraphQLSchema schema, GraphQLInterfaceType interfaceType) {
         Map<String, GraphQLType> allTypes = allTypes(schema, schema.getDictionary());
         List<GraphQLObjectType> result = new ArrayList<>();

--- a/src/main/java/graphql/schema/StaticDataFetcher.java
+++ b/src/main/java/graphql/schema/StaticDataFetcher.java
@@ -1,15 +1,27 @@
 package graphql.schema;
 
 
+/**
+ * <p>StaticDataFetcher class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class StaticDataFetcher implements DataFetcher {
 
 
     private final Object value;
 
+    /**
+     * <p>Constructor for StaticDataFetcher.</p>
+     *
+     * @param value a {@link java.lang.Object} object.
+     */
     public StaticDataFetcher(Object value) {
         this.value = value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Object get(DataFetchingEnvironment environment) {
         return value;

--- a/src/main/java/graphql/schema/TypeResolver.java
+++ b/src/main/java/graphql/schema/TypeResolver.java
@@ -1,9 +1,21 @@
 package graphql.schema;
 
 
+/**
+ * <p>TypeResolver interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface TypeResolver {
 
 
+    /**
+     * <p>getType.</p>
+     *
+     * @param object a {@link java.lang.Object} object.
+     * @return a {@link graphql.schema.GraphQLObjectType} object.
+     */
     GraphQLObjectType getType(Object object);
 
 }

--- a/src/main/java/graphql/schema/TypeResolverProxy.java
+++ b/src/main/java/graphql/schema/TypeResolverProxy.java
@@ -1,18 +1,35 @@
 package graphql.schema;
 
 
+/**
+ * <p>TypeResolverProxy class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.3
+ */
 public class TypeResolverProxy implements TypeResolver {
 
     private TypeResolver typeResolver;
 
+    /**
+     * <p>Getter for the field <code>typeResolver</code>.</p>
+     *
+     * @return a {@link graphql.schema.TypeResolver} object.
+     */
     public TypeResolver getTypeResolver() {
         return typeResolver;
     }
 
+    /**
+     * <p>Setter for the field <code>typeResolver</code>.</p>
+     *
+     * @param typeResolver a {@link graphql.schema.TypeResolver} object.
+     */
     public void setTypeResolver(TypeResolver typeResolver) {
         this.typeResolver = typeResolver;
     }
 
+    /** {@inheritDoc} */
     @Override
     public GraphQLObjectType getType(Object object) {
         return typeResolver != null ? typeResolver.getType(object) : null;

--- a/src/main/java/graphql/validation/AbstractRule.java
+++ b/src/main/java/graphql/validation/AbstractRule.java
@@ -5,6 +5,12 @@ import graphql.language.*;
 
 import java.util.List;
 
+/**
+ * <p>AbstractRule class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class AbstractRule {
 
     private final ValidationContext validationContext;
@@ -15,93 +21,205 @@ public class AbstractRule {
 
     private ValidationUtil validationUtil = new ValidationUtil();
 
+    /**
+     * <p>Constructor for AbstractRule.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public AbstractRule(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         this.validationContext = validationContext;
         this.validationErrorCollector = validationErrorCollector;
     }
 
+    /**
+     * <p>isVisitFragmentSpreads.</p>
+     *
+     * @return a boolean.
+     */
     public boolean isVisitFragmentSpreads() {
         return visitFragmentSpreads;
     }
 
+    /**
+     * <p>Setter for the field <code>visitFragmentSpreads</code>.</p>
+     *
+     * @param visitFragmentSpreads a boolean.
+     */
     public void setVisitFragmentSpreads(boolean visitFragmentSpreads) {
         this.visitFragmentSpreads = visitFragmentSpreads;
     }
 
 
+    /**
+     * <p>Getter for the field <code>validationUtil</code>.</p>
+     *
+     * @return a {@link graphql.validation.ValidationUtil} object.
+     */
     public ValidationUtil getValidationUtil() {
         return validationUtil;
     }
 
+    /**
+     * <p>Setter for the field <code>validationUtil</code>.</p>
+     *
+     * @param validationUtil a {@link graphql.validation.ValidationUtil} object.
+     */
     public void setValidationUtil(ValidationUtil validationUtil) {
         this.validationUtil = validationUtil;
     }
 
+    /**
+     * <p>addError.</p>
+     *
+     * @param error a {@link graphql.validation.ValidationError} object.
+     */
     public void addError(ValidationError error) {
         validationErrorCollector.addError(error);
     }
 
+    /**
+     * <p>getErrors.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<ValidationError> getErrors() {
         return validationErrorCollector.getErrors();
     }
 
 
+    /**
+     * <p>Getter for the field <code>validationContext</code>.</p>
+     *
+     * @return a {@link graphql.validation.ValidationContext} object.
+     */
     public ValidationContext getValidationContext() {
         return validationContext;
     }
 
+    /**
+     * <p>checkArgument.</p>
+     *
+     * @param argument a {@link graphql.language.Argument} object.
+     */
     public void checkArgument(Argument argument) {
 
     }
 
+    /**
+     * <p>checkTypeName.</p>
+     *
+     * @param typeName a {@link graphql.language.TypeName} object.
+     */
     public void checkTypeName(TypeName typeName) {
 
     }
 
+    /**
+     * <p>checkVariableDefinition.</p>
+     *
+     * @param variableDefinition a {@link graphql.language.VariableDefinition} object.
+     */
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
 
     }
 
+    /**
+     * <p>checkField.</p>
+     *
+     * @param field a {@link graphql.language.Field} object.
+     */
     public void checkField(Field field) {
 
     }
 
+    /**
+     * <p>checkInlineFragment.</p>
+     *
+     * @param inlineFragment a {@link graphql.language.InlineFragment} object.
+     */
     public void checkInlineFragment(InlineFragment inlineFragment) {
 
     }
 
+    /**
+     * <p>checkDirective.</p>
+     *
+     * @param directive a {@link graphql.language.Directive} object.
+     * @param ancestors a {@link java.util.List} object.
+     */
     public void checkDirective(Directive directive, List<Node> ancestors) {
 
     }
 
+    /**
+     * <p>checkFragmentSpread.</p>
+     *
+     * @param fragmentSpread a {@link graphql.language.FragmentSpread} object.
+     */
     public void checkFragmentSpread(FragmentSpread fragmentSpread) {
 
     }
 
+    /**
+     * <p>checkFragmentDefinition.</p>
+     *
+     * @param fragmentDefinition a {@link graphql.language.FragmentDefinition} object.
+     */
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
 
     }
 
+    /**
+     * <p>checkOperationDefinition.</p>
+     *
+     * @param operationDefinition a {@link graphql.language.OperationDefinition} object.
+     */
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
 
     }
 
+    /**
+     * <p>leaveOperationDefinition.</p>
+     *
+     * @param operationDefinition a {@link graphql.language.OperationDefinition} object.
+     */
     public void leaveOperationDefinition(OperationDefinition operationDefinition) {
 
     }
 
+    /**
+     * <p>checkSelectionSet.</p>
+     *
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public void checkSelectionSet(SelectionSet selectionSet) {
 
     }
 
+    /**
+     * <p>leaveSelectionSet.</p>
+     *
+     * @param selectionSet a {@link graphql.language.SelectionSet} object.
+     */
     public void leaveSelectionSet(SelectionSet selectionSet) {
 
     }
 
+    /**
+     * <p>checkVariable.</p>
+     *
+     * @param variableReference a {@link graphql.language.VariableReference} object.
+     */
     public void checkVariable(VariableReference variableReference) {
 
     }
 
+    /**
+     * <p>documentFinished.</p>
+     *
+     * @param document a {@link graphql.language.Document} object.
+     */
     public void documentFinished(Document document) {
 
     }

--- a/src/main/java/graphql/validation/ErrorFactory.java
+++ b/src/main/java/graphql/validation/ErrorFactory.java
@@ -7,9 +7,23 @@ import graphql.language.SourceLocation;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ErrorFactory class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class ErrorFactory {
 
 
+    /**
+     * <p>newError.</p>
+     *
+     * @param validationErrorType a {@link graphql.validation.ValidationErrorType} object.
+     * @param locations a {@link java.util.List} object.
+     * @param description a {@link java.lang.String} object.
+     * @return a {@link graphql.validation.ValidationError} object.
+     */
     public ValidationError newError(ValidationErrorType validationErrorType, List<? extends Node> locations, String description) {
         List<SourceLocation> locationList = new ArrayList<>();
         for (Node node : locations) {
@@ -18,6 +32,13 @@ public class ErrorFactory {
         return new ValidationError(validationErrorType, locationList, description);
     }
 
+    /**
+     * <p>newError.</p>
+     *
+     * @param validationErrorType a {@link graphql.validation.ValidationErrorType} object.
+     * @param description a {@link java.lang.String} object.
+     * @return a {@link graphql.validation.ValidationError} object.
+     */
     public ValidationError newError(ValidationErrorType validationErrorType, String description) {
         return new ValidationError(validationErrorType, (List) null, description);
     }

--- a/src/main/java/graphql/validation/LanguageTraversal.java
+++ b/src/main/java/graphql/validation/LanguageTraversal.java
@@ -6,9 +6,21 @@ import graphql.language.Node;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>LanguageTraversal class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class LanguageTraversal {
 
 
+    /**
+     * <p>traverse.</p>
+     *
+     * @param root a {@link graphql.language.Node} object.
+     * @param queryLanguageVisitor a {@link graphql.validation.QueryLanguageVisitor} object.
+     */
     public void traverse(Node root, QueryLanguageVisitor queryLanguageVisitor) {
         List<Node> path = new ArrayList<>();
         traverseImpl(root, queryLanguageVisitor, path);

--- a/src/main/java/graphql/validation/QueryLanguageVisitor.java
+++ b/src/main/java/graphql/validation/QueryLanguageVisitor.java
@@ -5,9 +5,27 @@ import graphql.language.Node;
 
 import java.util.List;
 
+/**
+ * <p>QueryLanguageVisitor interface.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public interface QueryLanguageVisitor {
 
+    /**
+     * <p>enter.</p>
+     *
+     * @param node a {@link graphql.language.Node} object.
+     * @param path a {@link java.util.List} object.
+     */
     void enter(Node node, List<Node> path);
 
+    /**
+     * <p>leave.</p>
+     *
+     * @param node a {@link graphql.language.Node} object.
+     * @param path a {@link java.util.List} object.
+     */
     void leave(Node node, List<Node> path);
 }

--- a/src/main/java/graphql/validation/RulesVisitor.java
+++ b/src/main/java/graphql/validation/RulesVisitor.java
@@ -5,6 +5,12 @@ import graphql.language.*;
 
 import java.util.*;
 
+/**
+ * <p>RulesVisitor class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class RulesVisitor implements QueryLanguageVisitor {
 
     private final List<AbstractRule> rules = new ArrayList<>();
@@ -14,10 +20,23 @@ public class RulesVisitor implements QueryLanguageVisitor {
     private Map<Node, List<AbstractRule>> rulesToSkipByUntilNode = new IdentityHashMap<>();
     private Set<AbstractRule> rulesToSkip = new LinkedHashSet<>();
 
+    /**
+     * <p>Constructor for RulesVisitor.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param rules a {@link java.util.List} object.
+     */
     public RulesVisitor(ValidationContext validationContext, List<AbstractRule> rules) {
         this(validationContext, rules, false);
     }
 
+    /**
+     * <p>Constructor for RulesVisitor.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param rules a {@link java.util.List} object.
+     * @param subVisitor a boolean.
+     */
     public RulesVisitor(ValidationContext validationContext, List<AbstractRule> rules, boolean subVisitor) {
         this.validationContext = validationContext;
         this.subVisitor = subVisitor;
@@ -34,6 +53,7 @@ public class RulesVisitor implements QueryLanguageVisitor {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void enter(Node node, List<Node> ancestors) {
 //        System.out.println("enter: " + node);
@@ -158,6 +178,7 @@ public class RulesVisitor implements QueryLanguageVisitor {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void leave(Node node, List<Node> ancestors) {
         validationContext.getTraversalContext().leave(node, ancestors);

--- a/src/main/java/graphql/validation/TraversalContext.java
+++ b/src/main/java/graphql/validation/TraversalContext.java
@@ -11,6 +11,12 @@ import java.util.List;
 
 import static graphql.introspection.Introspection.*;
 
+/**
+ * <p>TraversalContext class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class TraversalContext implements QueryLanguageVisitor {
     GraphQLSchema schema;
     List<GraphQLOutputType> outputTypeStack = new ArrayList<>();
@@ -23,10 +29,16 @@ public class TraversalContext implements QueryLanguageVisitor {
     SchemaUtil schemaUtil = new SchemaUtil();
 
 
+    /**
+     * <p>Constructor for TraversalContext.</p>
+     *
+     * @param graphQLSchema a {@link graphql.schema.GraphQLSchema} object.
+     */
     public TraversalContext(GraphQLSchema graphQLSchema) {
         this.schema = graphQLSchema;
     }
 
+    /** {@inheritDoc} */
     @Override
     public void enter(Node node, List<Node> path) {
         if (node instanceof OperationDefinition) {
@@ -141,6 +153,7 @@ public class TraversalContext implements QueryLanguageVisitor {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void leave(Node node, List<Node> ancestors) {
         if (node instanceof OperationDefinition) {
@@ -173,6 +186,11 @@ public class TraversalContext implements QueryLanguageVisitor {
         return (GraphQLNullableType) (type instanceof GraphQLNonNull ? ((GraphQLNonNull) type).getWrappedType() : type);
     }
 
+    /**
+     * <p>getOutputType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLOutputType} object.
+     */
     public GraphQLOutputType getOutputType() {
         return lastElement(outputTypeStack);
     }
@@ -187,6 +205,11 @@ public class TraversalContext implements QueryLanguageVisitor {
         return list.get(list.size() - 1);
     }
 
+    /**
+     * <p>getParentType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLCompositeType} object.
+     */
     public GraphQLCompositeType getParentType() {
         return lastElement(parentTypeStack);
     }
@@ -195,6 +218,11 @@ public class TraversalContext implements QueryLanguageVisitor {
         parentTypeStack.add(compositeType);
     }
 
+    /**
+     * <p>getInputType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInputType} object.
+     */
     public GraphQLInputType getInputType() {
         return lastElement(inputTypeStack);
     }
@@ -203,6 +231,11 @@ public class TraversalContext implements QueryLanguageVisitor {
         inputTypeStack.add(graphQLInputType);
     }
 
+    /**
+     * <p>getFieldDef.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLFieldDefinition} object.
+     */
     public GraphQLFieldDefinition getFieldDef() {
         return lastElement(fieldDefStack);
     }
@@ -211,10 +244,20 @@ public class TraversalContext implements QueryLanguageVisitor {
         fieldDefStack.add(fieldDefinition);
     }
 
+    /**
+     * <p>Getter for the field <code>directive</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLDirective} object.
+     */
     public GraphQLDirective getDirective() {
         return directive;
     }
 
+    /**
+     * <p>Getter for the field <code>argument</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLArgument} object.
+     */
     public GraphQLArgument getArgument() {
         return argument;
     }

--- a/src/main/java/graphql/validation/ValidationContext.java
+++ b/src/main/java/graphql/validation/ValidationContext.java
@@ -9,6 +9,12 @@ import graphql.schema.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>ValidationContext class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ValidationContext {
 
     private final GraphQLSchema schema;
@@ -18,6 +24,12 @@ public class ValidationContext {
     private final Map<String, FragmentDefinition> fragmentDefinitionMap = new LinkedHashMap<>();
 
 
+    /**
+     * <p>Constructor for ValidationContext.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param document a {@link graphql.language.Document} object.
+     */
     public ValidationContext(GraphQLSchema schema, Document document) {
         this.schema = schema;
         this.document = document;
@@ -33,42 +45,93 @@ public class ValidationContext {
         }
     }
 
+    /**
+     * <p>Getter for the field <code>traversalContext</code>.</p>
+     *
+     * @return a {@link graphql.validation.TraversalContext} object.
+     */
     public TraversalContext getTraversalContext() {
         return traversalContext;
     }
 
+    /**
+     * <p>Getter for the field <code>schema</code>.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLSchema} object.
+     */
     public GraphQLSchema getSchema() {
         return schema;
     }
 
+    /**
+     * <p>Getter for the field <code>document</code>.</p>
+     *
+     * @return a {@link graphql.language.Document} object.
+     */
     public Document getDocument() {
         return document;
     }
 
+    /**
+     * <p>getFragment.</p>
+     *
+     * @param name a {@link java.lang.String} object.
+     * @return a {@link graphql.language.FragmentDefinition} object.
+     */
     public FragmentDefinition getFragment(String name) {
         return fragmentDefinitionMap.get(name);
     }
 
+    /**
+     * <p>getParentType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLCompositeType} object.
+     */
     public GraphQLCompositeType getParentType() {
         return traversalContext.getParentType();
     }
 
+    /**
+     * <p>getInputType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLInputType} object.
+     */
     public GraphQLInputType getInputType() {
         return traversalContext.getInputType();
     }
 
+    /**
+     * <p>getFieldDef.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLFieldDefinition} object.
+     */
     public GraphQLFieldDefinition getFieldDef() {
         return traversalContext.getFieldDef();
     }
 
+    /**
+     * <p>getDirective.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLDirective} object.
+     */
     public GraphQLDirective getDirective() {
         return traversalContext.getDirective();
     }
 
+    /**
+     * <p>getArgument.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLArgument} object.
+     */
     public GraphQLArgument getArgument() {
         return traversalContext.getArgument();
     }
 
+    /**
+     * <p>getOutputType.</p>
+     *
+     * @return a {@link graphql.schema.GraphQLOutputType} object.
+     */
     public GraphQLOutputType getOutputType() {
         return traversalContext.getOutputType();
     }

--- a/src/main/java/graphql/validation/ValidationError.java
+++ b/src/main/java/graphql/validation/ValidationError.java
@@ -8,6 +8,12 @@ import graphql.language.SourceLocation;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ValidationError class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ValidationError implements GraphQLError {
 
 
@@ -15,10 +21,22 @@ public class ValidationError implements GraphQLError {
     private final List<SourceLocation> sourceLocations = new ArrayList<>();
     private final String description;
 
+    /**
+     * <p>Constructor for ValidationError.</p>
+     *
+     * @param validationErrorType a {@link graphql.validation.ValidationErrorType} object.
+     */
     public ValidationError(ValidationErrorType validationErrorType) {
         this(validationErrorType, (SourceLocation) null, null);
     }
 
+    /**
+     * <p>Constructor for ValidationError.</p>
+     *
+     * @param validationErrorType a {@link graphql.validation.ValidationErrorType} object.
+     * @param sourceLocation a {@link graphql.language.SourceLocation} object.
+     * @param description a {@link java.lang.String} object.
+     */
     public ValidationError(ValidationErrorType validationErrorType, SourceLocation sourceLocation, String description) {
         this.validationErrorType = validationErrorType;
         if (sourceLocation != null)
@@ -26,6 +44,13 @@ public class ValidationError implements GraphQLError {
         this.description = description;
     }
 
+    /**
+     * <p>Constructor for ValidationError.</p>
+     *
+     * @param validationErrorType a {@link graphql.validation.ValidationErrorType} object.
+     * @param sourceLocations a {@link java.util.List} object.
+     * @param description a {@link java.lang.String} object.
+     */
     public ValidationError(ValidationErrorType validationErrorType, List<SourceLocation> sourceLocations, String description) {
         this.validationErrorType = validationErrorType;
         if (sourceLocations != null)
@@ -33,26 +58,35 @@ public class ValidationError implements GraphQLError {
         this.description = description;
     }
 
+    /**
+     * <p>Getter for the field <code>validationErrorType</code>.</p>
+     *
+     * @return a {@link graphql.validation.ValidationErrorType} object.
+     */
     public ValidationErrorType getValidationErrorType() {
         return validationErrorType;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getMessage() {
         return String.format("Validation error of type %s: %s", validationErrorType, description);
     }
 
+    /** {@inheritDoc} */
     @Override
     public List<SourceLocation> getLocations() {
         return sourceLocations;
     }
 
+    /** {@inheritDoc} */
     @Override
     public ErrorType getErrorType() {
         return ErrorType.ValidationError;
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "ValidationError{" +

--- a/src/main/java/graphql/validation/ValidationErrorCollector.java
+++ b/src/main/java/graphql/validation/ValidationErrorCollector.java
@@ -4,18 +4,40 @@ package graphql.validation;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>ValidationErrorCollector class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class ValidationErrorCollector {
 
     private final List<ValidationError> errors = new ArrayList<>();
 
+    /**
+     * <p>addError.</p>
+     *
+     * @param validationError a {@link graphql.validation.ValidationError} object.
+     */
     public void addError(ValidationError validationError){
         this.errors.add(validationError);
     }
 
+    /**
+     * <p>Getter for the field <code>errors</code>.</p>
+     *
+     * @return a {@link java.util.List} object.
+     */
     public List<ValidationError> getErrors(){
         return errors;
     }
 
+    /**
+     * <p>containsValidationError.</p>
+     *
+     * @param validationErrorType a {@link graphql.validation.ValidationErrorType} object.
+     * @return a boolean.
+     */
     public boolean containsValidationError(ValidationErrorType validationErrorType){
         for(ValidationError validationError : errors){
             if(validationError.getValidationErrorType() == validationErrorType) return true;

--- a/src/main/java/graphql/validation/ValidationErrorType.java
+++ b/src/main/java/graphql/validation/ValidationErrorType.java
@@ -1,6 +1,12 @@
 package graphql.validation;
 
 
+/**
+ * <p>ValidationErrorType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public enum ValidationErrorType {
 
     DefaultForNonNullArgument,

--- a/src/main/java/graphql/validation/ValidationUtil.java
+++ b/src/main/java/graphql/validation/ValidationUtil.java
@@ -8,8 +8,20 @@ import graphql.schema.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>ValidationUtil class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ValidationUtil {
 
+    /**
+     * <p>getUnmodifiedType.</p>
+     *
+     * @param type a {@link graphql.language.Type} object.
+     * @return a {@link graphql.language.TypeName} object.
+     */
     public TypeName getUnmodifiedType(Type type) {
         if (type instanceof ListType) {
             return getUnmodifiedType(((ListType) type).getType());
@@ -21,6 +33,13 @@ public class ValidationUtil {
         throw new ShouldNotHappenException();
     }
 
+    /**
+     * <p>isValidLiteralValue.</p>
+     *
+     * @param value a {@link graphql.language.Value} object.
+     * @param type a {@link graphql.schema.GraphQLType} object.
+     * @return a boolean.
+     */
     public boolean isValidLiteralValue(Value value, GraphQLType type) {
         if (value == null) {
             return !(type instanceof GraphQLNonNull);

--- a/src/main/java/graphql/validation/Validator.java
+++ b/src/main/java/graphql/validation/Validator.java
@@ -8,8 +8,21 @@ import graphql.validation.rules.*;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p>Validator class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class Validator {
 
+    /**
+     * <p>validateDocument.</p>
+     *
+     * @param schema a {@link graphql.schema.GraphQLSchema} object.
+     * @param document a {@link graphql.language.Document} object.
+     * @return a {@link java.util.List} object.
+     */
     public List<ValidationError> validateDocument(GraphQLSchema schema, Document document) {
         ValidationContext validationContext = new ValidationContext(schema, document);
 

--- a/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/ArgumentsOfCorrectType.java
@@ -5,12 +5,25 @@ import graphql.language.Argument;
 import graphql.schema.GraphQLArgument;
 import graphql.validation.*;
 
+/**
+ * <p>ArgumentsOfCorrectType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ArgumentsOfCorrectType extends AbstractRule {
 
+    /**
+     * <p>Constructor for ArgumentsOfCorrectType.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public ArgumentsOfCorrectType(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkArgument(Argument argument) {
         GraphQLArgument fieldArgument = getValidationContext().getArgument();

--- a/src/main/java/graphql/validation/rules/FieldsOnCorrectType.java
+++ b/src/main/java/graphql/validation/rules/FieldsOnCorrectType.java
@@ -6,14 +6,27 @@ import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.validation.*;
 
+/**
+ * <p>FieldsOnCorrectType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class FieldsOnCorrectType extends AbstractRule {
 
 
+    /**
+     * <p>Constructor for FieldsOnCorrectType.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public FieldsOnCorrectType(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkField(Field field) {
         GraphQLCompositeType parentType = getValidationContext().getParentType();

--- a/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
+++ b/src/main/java/graphql/validation/rules/FragmentsOnCompositeType.java
@@ -7,13 +7,26 @@ import graphql.schema.GraphQLCompositeType;
 import graphql.schema.GraphQLType;
 import graphql.validation.*;
 
+/**
+ * <p>FragmentsOnCompositeType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class FragmentsOnCompositeType extends AbstractRule {
 
 
+    /**
+     * <p>Constructor for FragmentsOnCompositeType.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public FragmentsOnCompositeType(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkInlineFragment(InlineFragment inlineFragment) {
         GraphQLType type = getValidationContext().getSchema().getType(inlineFragment.getTypeCondition().getName());
@@ -24,6 +37,7 @@ public class FragmentsOnCompositeType extends AbstractRule {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
         GraphQLType type = getValidationContext().getSchema().getType(fragmentDefinition.getTypeCondition().getName());

--- a/src/main/java/graphql/validation/rules/KnownArgumentNames.java
+++ b/src/main/java/graphql/validation/rules/KnownArgumentNames.java
@@ -6,13 +6,26 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.validation.*;
 
 
+/**
+ * <p>KnownArgumentNames class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class KnownArgumentNames extends AbstractRule {
 
+    /**
+     * <p>Constructor for KnownArgumentNames.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public KnownArgumentNames(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkArgument(Argument argument) {
         GraphQLFieldDefinition fieldDef = getValidationContext().getFieldDef();

--- a/src/main/java/graphql/validation/rules/KnownDirectives.java
+++ b/src/main/java/graphql/validation/rules/KnownDirectives.java
@@ -7,13 +7,26 @@ import graphql.validation.*;
 
 import java.util.List;
 
+/**
+ * <p>KnownDirectives class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class KnownDirectives extends AbstractRule {
 
 
+    /**
+     * <p>Constructor for KnownDirectives.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public KnownDirectives(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkDirective(Directive directive, List<Node> ancestors) {
         GraphQLDirective graphQLDirective = getValidationContext().getSchema().getDirective(directive.getName());

--- a/src/main/java/graphql/validation/rules/KnownFragmentNames.java
+++ b/src/main/java/graphql/validation/rules/KnownFragmentNames.java
@@ -5,12 +5,25 @@ import graphql.language.FragmentDefinition;
 import graphql.language.FragmentSpread;
 import graphql.validation.*;
 
+/**
+ * <p>KnownFragmentNames class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class KnownFragmentNames extends AbstractRule {
 
+    /**
+     * <p>Constructor for KnownFragmentNames.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public KnownFragmentNames(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentSpread(FragmentSpread fragmentSpread) {
         FragmentDefinition fragmentDefinition = getValidationContext().getFragment(fragmentSpread.getName());

--- a/src/main/java/graphql/validation/rules/KnownTypeNames.java
+++ b/src/main/java/graphql/validation/rules/KnownTypeNames.java
@@ -4,13 +4,26 @@ package graphql.validation.rules;
 import graphql.language.TypeName;
 import graphql.validation.*;
 
+/**
+ * <p>KnownTypeNames class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class KnownTypeNames extends AbstractRule {
 
 
+    /**
+     * <p>Constructor for KnownTypeNames.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public KnownTypeNames(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkTypeName(TypeName typeName) {
         if ((getValidationContext().getSchema().getType(typeName.getName())) == null) {

--- a/src/main/java/graphql/validation/rules/NoFragmentCycles.java
+++ b/src/main/java/graphql/validation/rules/NoFragmentCycles.java
@@ -12,11 +12,23 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>NoFragmentCycles class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class NoFragmentCycles extends AbstractRule {
 
     private Map<String, List<FragmentSpread>> fragmentSpreads = new LinkedHashMap<>();
 
 
+    /**
+     * <p>Constructor for NoFragmentCycles.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public NoFragmentCycles(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
         prepareFragmentMap();
@@ -54,6 +66,7 @@ public class NoFragmentCycles extends AbstractRule {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
         List<FragmentSpread> spreadPath = new ArrayList<>();

--- a/src/main/java/graphql/validation/rules/NoUndefinedVariables.java
+++ b/src/main/java/graphql/validation/rules/NoUndefinedVariables.java
@@ -10,25 +10,40 @@ import graphql.validation.*;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+/**
+ * <p>NoUndefinedVariables class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class NoUndefinedVariables extends AbstractRule {
 
     private Set<String> variableNames = new LinkedHashSet<>();
 
+    /**
+     * <p>Constructor for NoUndefinedVariables.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public NoUndefinedVariables(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
         setVisitFragmentSpreads(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
         variableNames.clear();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
         super.checkFragmentDefinition(fragmentDefinition);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariable(VariableReference variableReference) {
         if (!variableNames.contains(variableReference.getName())) {
@@ -37,6 +52,7 @@ public class NoUndefinedVariables extends AbstractRule {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
         variableNames.add(variableDefinition.getName());

--- a/src/main/java/graphql/validation/rules/NoUnusedFragments.java
+++ b/src/main/java/graphql/validation/rules/NoUnusedFragments.java
@@ -12,6 +12,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>NoUnusedFragments class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class NoUnusedFragments extends AbstractRule {
 
 
@@ -21,10 +27,17 @@ public class NoUnusedFragments extends AbstractRule {
     private Map<String, List<String>> spreadsInDefinition = new LinkedHashMap<>();
     private final List<List<String>> fragmentsUsedDirectlyInOperation = new ArrayList<>();
 
+    /**
+     * <p>Constructor for NoUnusedFragments.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public NoUnusedFragments(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
         usedFragments = new ArrayList<>();
@@ -32,11 +45,13 @@ public class NoUnusedFragments extends AbstractRule {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentSpread(FragmentSpread fragmentSpread) {
         usedFragments.add(fragmentSpread.getName());
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentDefinition(FragmentDefinition fragmentDefinition) {
         allDeclaredFragments.add(fragmentDefinition);
@@ -44,6 +59,7 @@ public class NoUnusedFragments extends AbstractRule {
         spreadsInDefinition.put(fragmentDefinition.getName(), usedFragments);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void documentFinished(Document document) {
 

--- a/src/main/java/graphql/validation/rules/NoUnusedVariables.java
+++ b/src/main/java/graphql/validation/rules/NoUnusedVariables.java
@@ -11,16 +11,29 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * <p>NoUnusedVariables class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class NoUnusedVariables extends AbstractRule {
 
     private List<VariableDefinition> variableDefinitions = new ArrayList<>();
     private Set<String> usedVariables = new LinkedHashSet<>();
 
+    /**
+     * <p>Constructor for NoUnusedVariables.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public NoUnusedVariables(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
         setVisitFragmentSpreads(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void leaveOperationDefinition(OperationDefinition operationDefinition) {
         for (VariableDefinition variableDefinition : variableDefinitions) {
@@ -31,17 +44,20 @@ public class NoUnusedVariables extends AbstractRule {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
         usedVariables.clear();
         variableDefinitions.clear();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
         variableDefinitions.add(variableDefinition);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariable(VariableReference variableReference) {
         usedVariables.add(variableReference.getName());

--- a/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
+++ b/src/main/java/graphql/validation/rules/OverlappingFieldsCanBeMerged.java
@@ -13,6 +13,12 @@ import java.util.*;
 
 import static graphql.validation.ValidationErrorType.FieldsConflict;
 
+/**
+ * <p>OverlappingFieldsCanBeMerged class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class OverlappingFieldsCanBeMerged extends AbstractRule {
 
     ErrorFactory errorFactory = new ErrorFactory();
@@ -20,10 +26,17 @@ public class OverlappingFieldsCanBeMerged extends AbstractRule {
 
     private List<FieldPair> alreadyChecked = new ArrayList<>();
 
+    /**
+     * <p>Constructor for OverlappingFieldsCanBeMerged.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public OverlappingFieldsCanBeMerged(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void leaveSelectionSet(SelectionSet selectionSet) {
         Map<String, List<FieldAndType>> fieldMap = new LinkedHashMap<>();

--- a/src/main/java/graphql/validation/rules/PossibleFragmentSpreads.java
+++ b/src/main/java/graphql/validation/rules/PossibleFragmentSpreads.java
@@ -12,13 +12,26 @@ import graphql.validation.*;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * <p>PossibleFragmentSpreads class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class PossibleFragmentSpreads extends AbstractRule {
 
+    /**
+     * <p>Constructor for PossibleFragmentSpreads.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public PossibleFragmentSpreads(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkInlineFragment(InlineFragment inlineFragment) {
         GraphQLOutputType fragType = getValidationContext().getOutputType();
@@ -32,6 +45,7 @@ public class PossibleFragmentSpreads extends AbstractRule {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkFragmentSpread(FragmentSpread fragmentSpread) {
         FragmentDefinition fragment = getValidationContext().getFragment(fragmentSpread.getName());

--- a/src/main/java/graphql/validation/rules/ProvidedNonNullArguments.java
+++ b/src/main/java/graphql/validation/rules/ProvidedNonNullArguments.java
@@ -15,12 +15,25 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * <p>ProvidedNonNullArguments class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ProvidedNonNullArguments extends AbstractRule {
 
+    /**
+     * <p>Constructor for ProvidedNonNullArguments.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public ProvidedNonNullArguments(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkField(Field field) {
         GraphQLFieldDefinition fieldDef = getValidationContext().getFieldDef();
@@ -46,6 +59,7 @@ public class ProvidedNonNullArguments extends AbstractRule {
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkDirective(Directive directive, List<Node> ancestors) {
         GraphQLDirective graphQLDirective = getValidationContext().getDirective();

--- a/src/main/java/graphql/validation/rules/ScalarLeafs.java
+++ b/src/main/java/graphql/validation/rules/ScalarLeafs.java
@@ -6,14 +6,27 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.SchemaUtil;
 import graphql.validation.*;
 
+/**
+ * <p>ScalarLeafs class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class ScalarLeafs extends AbstractRule {
 
     private SchemaUtil schemaUtil = new SchemaUtil();
 
+    /**
+     * <p>Constructor for ScalarLeafs.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public ScalarLeafs(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkField(Field field) {
         GraphQLOutputType type = getValidationContext().getOutputType();

--- a/src/main/java/graphql/validation/rules/VariableDefaultValuesOfCorrectType.java
+++ b/src/main/java/graphql/validation/rules/VariableDefaultValuesOfCorrectType.java
@@ -6,14 +6,27 @@ import graphql.schema.GraphQLNonNull;
 import graphql.validation.*;
 
 
+/**
+ * <p>VariableDefaultValuesOfCorrectType class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class VariableDefaultValuesOfCorrectType extends AbstractRule {
 
 
+    /**
+     * <p>Constructor for VariableDefaultValuesOfCorrectType.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public VariableDefaultValuesOfCorrectType(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
         GraphQLInputType inputType = getValidationContext().getInputType();

--- a/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
+++ b/src/main/java/graphql/validation/rules/VariableTypesMatchRule.java
@@ -12,10 +12,22 @@ import graphql.validation.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * <p>VariableTypesMatchRule class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class VariableTypesMatchRule extends AbstractRule {
 
     VariablesTypesMatcher variablesTypesMatcher = new VariablesTypesMatcher();
 
+    /**
+     * <p>Constructor for VariableTypesMatchRule.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public VariableTypesMatchRule(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
         setVisitFragmentSpreads(true);
@@ -23,16 +35,19 @@ public class VariableTypesMatchRule extends AbstractRule {
 
     private Map<String, VariableDefinition> variableDefinitionMap;
 
+    /** {@inheritDoc} */
     @Override
     public void checkOperationDefinition(OperationDefinition operationDefinition) {
         variableDefinitionMap = new LinkedHashMap<>();
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
         variableDefinitionMap.put(variableDefinition.getName(), variableDefinition);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariable(VariableReference variableReference) {
         VariableDefinition variableDefinition = variableDefinitionMap.get(variableReference.getName());

--- a/src/main/java/graphql/validation/rules/VariablesAreInputTypes.java
+++ b/src/main/java/graphql/validation/rules/VariablesAreInputTypes.java
@@ -7,14 +7,27 @@ import graphql.schema.GraphQLType;
 import graphql.schema.SchemaUtil;
 import graphql.validation.*;
 
+/**
+ * <p>VariablesAreInputTypes class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.0
+ */
 public class VariablesAreInputTypes extends AbstractRule {
 
     private SchemaUtil schemaUtil = new SchemaUtil();
 
+    /**
+     * <p>Constructor for VariablesAreInputTypes.</p>
+     *
+     * @param validationContext a {@link graphql.validation.ValidationContext} object.
+     * @param validationErrorCollector a {@link graphql.validation.ValidationErrorCollector} object.
+     */
     public VariablesAreInputTypes(ValidationContext validationContext, ValidationErrorCollector validationErrorCollector) {
         super(validationContext, validationErrorCollector);
     }
 
+    /** {@inheritDoc} */
     @Override
     public void checkVariableDefinition(VariableDefinition variableDefinition) {
         TypeName unmodifiedAstType = getValidationUtil().getUnmodifiedType(variableDefinition.getType());

--- a/src/main/java/graphql/validation/rules/VariablesTypesMatcher.java
+++ b/src/main/java/graphql/validation/rules/VariablesTypesMatcher.java
@@ -6,8 +6,22 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
 
+/**
+ * <p>VariablesTypesMatcher class.</p>
+ *
+ * @author Andreas Marek
+ * @version v1.2
+ */
 public class VariablesTypesMatcher {
 
+    /**
+     * <p>doesVariableTypesMatch.</p>
+     *
+     * @param variableType a {@link graphql.schema.GraphQLType} object.
+     * @param variableDefaultValue a {@link graphql.language.Value} object.
+     * @param expectedType a {@link graphql.schema.GraphQLType} object.
+     * @return a boolean.
+     */
     public boolean doesVariableTypesMatch(GraphQLType variableType, Value variableDefaultValue, GraphQLType expectedType) {
         return checkType(effectiveType(variableType, variableDefaultValue), expectedType);
     }


### PR DESCRIPTION
Andi,
I have autogenerated as much javadoc as the tools could reach, although it appears some classes were missed.
Everything is tagged with your name and versions v1.0, v1.2, v1.3 as applicable.
New classes since the v1.3 tag have had their @version erased.  That's basically anything in graphql.execution.batched.*
From this basis we all should be able to assist in focusing on the important sections of javadoc.


I am now reading on git author/committer, and how to set that, in case you want to maintain history as last edited by you.


FYI, the way I did it was turn this into a maven project then run maven-javadoc-plugin's javadoc:fix