### PR TITLE
Support IntValue tokens with larger value than INT_MAX

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -1,6 +1,8 @@
 package graphql;
 
 
+import java.math.BigInteger;
+
 import graphql.language.BooleanValue;
 import graphql.language.FloatValue;
 import graphql.language.IntValue;
@@ -31,7 +33,10 @@ public class Scalars {
         @Override
         public Object parseLiteral(Object input) {
             if (!(input instanceof IntValue)) return null;
-            return ((IntValue) input).getValue().intValueExact();
+            BigInteger value = ((IntValue) input).getValue();
+            // Check if out of bounds.
+            Integer.parseInt(value.toString());
+            return value.intValue();
         }
     });
 
@@ -60,7 +65,10 @@ public class Scalars {
             if (input instanceof StringValue) {
                 return Long.parseLong(((StringValue) input).getValue());
             } else if (input instanceof IntValue) {
-                return ((IntValue) input).getValue().longValueExact();
+                BigInteger value = ((IntValue) input).getValue();
+                // Check if out of bounds.
+                Long.parseLong(value.toString());
+                return value.longValue();
             }
             return null;
         }

--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -31,7 +31,7 @@ public class Scalars {
         @Override
         public Object parseLiteral(Object input) {
             if (!(input instanceof IntValue)) return null;
-            return ((IntValue) input).getValue();
+            return ((IntValue) input).getValue().intValueExact();
         }
     });
 
@@ -60,7 +60,7 @@ public class Scalars {
             if (input instanceof StringValue) {
                 return Long.parseLong(((StringValue) input).getValue());
             } else if (input instanceof IntValue) {
-                return ((IntValue) input).getValue();
+                return ((IntValue) input).getValue().longValueExact();
             }
             return null;
         }

--- a/src/main/java/graphql/language/IntValue.java
+++ b/src/main/java/graphql/language/IntValue.java
@@ -1,22 +1,23 @@
 package graphql.language;
 
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
 public class IntValue extends AbstractNode implements Value {
 
-    private int value;
+    private BigInteger value;
 
-    public IntValue(int value) {
+    public IntValue(BigInteger value) {
         this.value = value;
     }
 
-    public int getValue() {
+    public BigInteger getValue() {
         return value;
     }
 
-    public void setValue(int value) {
+    public void setValue(BigInteger value) {
         this.value = value;
     }
 
@@ -30,9 +31,9 @@ public class IntValue extends AbstractNode implements Value {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        IntValue intValue = (IntValue) o;
+        IntValue that = (IntValue) o;
 
-        return value == intValue.value;
+        return !(value != null ? !value.equals(that.value) : that.value != null);
 
     }
 

--- a/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
+++ b/src/main/java/graphql/parser/GraphqlAntlrToLanguage.java
@@ -8,6 +8,7 @@ import graphql.parser.antlr.GraphqlParser;
 import org.antlr.v4.runtime.ParserRuleContext;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -321,7 +322,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
     private Value getValue(GraphqlParser.ValueWithVariableContext ctx) {
         if (ctx.IntValue() != null) {
-            IntValue intValue = new IntValue(Integer.parseInt(ctx.IntValue().getText()));
+            IntValue intValue = new IntValue(new BigInteger(ctx.IntValue().getText()));
             newNode(intValue, ctx);
             return intValue;
         } else if (ctx.FloatValue() != null) {
@@ -366,7 +367,7 @@ public class GraphqlAntlrToLanguage extends GraphqlBaseVisitor<Void> {
 
     private Value getValue(GraphqlParser.ValueContext ctx) {
         if (ctx.IntValue() != null) {
-            IntValue intValue = new IntValue(Integer.parseInt(ctx.IntValue().getText()));
+            IntValue intValue = new IntValue(new BigInteger(ctx.IntValue().getText()));
             newNode(intValue, ctx);
             return intValue;
         } else if (ctx.FloatValue() != null) {

--- a/src/test/groovy/graphql/ScalarsTest.groovy
+++ b/src/test/groovy/graphql/ScalarsTest.groovy
@@ -56,9 +56,10 @@ class ScalarsTest extends Specification {
         Scalars.GraphQLLong.getCoercing().parseLiteral(literal) == result
 
         where:
-        literal               | result
-        new StringValue("42") | 42
-        new IntValue(42)      | 42
+        literal                          | result
+        new StringValue("42")            | 42
+        new IntValue(42)                 | 42
+        new IntValue(42345784398534785l) | 42345784398534785l
     }
 
 


### PR DESCRIPTION
IntValue now stores BigInteger instead of int. GraphQLInt and
GraphQLLong parseLiteral will throw if the value overflows int or long
respectively.

StringValue parsing for GraphQLLong is still supported for backwards
compatibility.

Add a test for parsing GraphQLLong larger than INT_MAX.