### PR TITLE
Throwable cause instead of Exception

### DIFF
--- a/src/main/java/graphql/ExceptionWhileDataFetching.java
+++ b/src/main/java/graphql/ExceptionWhileDataFetching.java
@@ -7,13 +7,13 @@ import java.util.List;
 
 public class ExceptionWhileDataFetching implements GraphQLError {
 
-    private final Exception exception;
+    private final Throwable exception;
 
-    public ExceptionWhileDataFetching(Exception exception) {
+    public ExceptionWhileDataFetching(Throwable exception) {
         this.exception = exception;
     }
 
-    public Exception getException() {
+    public Throwable getException() {
         return exception;
     }
 


### PR DESCRIPTION
Some JDK APIs such as CompletableFutures generate Throwables instead of
Exceptions.

Exception has no additional methods than Throwable, and all tests are passing.