### PR TITLE
Support parsing IntValue literals into GraphQLFloat

### DIFF
--- a/src/main/java/graphql/Scalars.java
+++ b/src/main/java/graphql/Scalars.java
@@ -100,7 +100,13 @@ public class Scalars {
 
         @Override
         public Object parseLiteral(Object input) {
-            return ((FloatValue) input).getValue().doubleValue();
+            if (input instanceof IntValue) {
+                return ((IntValue) input).getValue().doubleValue();
+            } else if (input instanceof FloatValue) {
+                return ((FloatValue) input).getValue().doubleValue();
+            } else {
+                return null;
+            }
         }
     });
 

--- a/src/test/groovy/graphql/ScalarsTest.groovy
+++ b/src/test/groovy/graphql/ScalarsTest.groovy
@@ -115,8 +115,10 @@ class ScalarsTest extends Specification {
         Scalars.GraphQLFloat.getCoercing().parseLiteral(literal) == result
 
         where:
-        literal              | result
-        new FloatValue(42.3) | 42.3d
+        literal                | result
+        new FloatValue(42.3)   | 42.3d
+        new IntValue(42)       | 42.0d
+        new StringValue("foo") | null
     }
 
     @Unroll


### PR DESCRIPTION
Hello!

We noticed a problem with the GraphQLFloat data type. If you send a literal number e.g. `2`, it will be parsed as IntValue and therefore throw an exception in the Scalars.parseLiteral for floats. There is a workaround to send e.g. `2.00001` but probably integers should be accepted here.

-Markku
https://github.com/HSLdevcom/digitransit-ui